### PR TITLE
Push all API methods into the APIClient

### DIFF
--- a/src/main/java/com/oneops/api/APIClient.java
+++ b/src/main/java/com/oneops/api/APIClient.java
@@ -1,45 +1,3742 @@
 package com.oneops.api;
 
-import org.apache.commons.codec.binary.Base64;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.concurrent.TimeUnit;
 
+import org.apache.commons.codec.binary.Base64;
+import org.json.JSONObject;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.google.common.base.Strings;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import com.google.common.util.concurrent.Uninterruptibles;
 import com.jayway.restassured.RestAssured;
 import com.jayway.restassured.config.SSLConfig;
+import com.jayway.restassured.path.json.JsonPath;
+import com.jayway.restassured.response.Response;
 import com.jayway.restassured.specification.RequestSpecification;
 import com.oneops.api.exception.OneOpsClientAPIException;
+import com.oneops.api.resource.model.AttrProps;
+import com.oneops.api.resource.model.CiAttributes;
+import com.oneops.api.resource.model.CiResource;
+import com.oneops.api.resource.model.Deployment;
+import com.oneops.api.resource.model.DeploymentRFC;
+import com.oneops.api.resource.model.Log;
+import com.oneops.api.resource.model.Organization;
+import com.oneops.api.resource.model.Procedure;
+import com.oneops.api.resource.model.RedundancyConfig;
+import com.oneops.api.resource.model.Release;
+import com.oneops.api.util.IConstants;
+import com.oneops.api.util.JsonUtil;
 
 public abstract class APIClient {
-	
-	OOInstance instance;
 
-	public APIClient(OOInstance instance) throws OneOpsClientAPIException {
-		this.instance = instance;
-		if(instance == null) {
-			throw new OneOpsClientAPIException("Missing OneOps instance information to perform API invocation");
-		}
-		if(instance.getAuthtoken() == null) {
-			throw new OneOpsClientAPIException("Missing OneOps authentication API key to perform API invocation");
-		}
-		if(instance.getEndpoint() == null) {
-			throw new OneOpsClientAPIException("Missing OneOps endpoint to perform API invocation");
-		}
-	}
-	
-	protected RequestSpecification createRequest() {
-		RequestSpecification rs = RestAssured.given();
-		String basicAuth = "Basic " + new String(Base64.encodeBase64(instance.getAuthtoken().getBytes()));
-		rs.header("Authorization", basicAuth);
-		rs.header("User-Agent", "OneOpsAPIClient");
-		rs.header("Accept", "application/json");
-		rs.header("Content-Type", "application/json");
-		String baseUri = instance.getEndpoint();
-		if(instance.getOrgname() != null) {
-			baseUri += instance.getOrgname();
-		}
-		rs.baseUri(baseUri);
-		rs.config(RestAssured.config().sslConfig(
-				new SSLConfig().relaxedHTTPSValidation()));
-		return rs;
-	}
-	
-	
+  private final OOInstance instance;
+
+  public APIClient(OOInstance instance) throws OneOpsClientAPIException {
+    this.instance = instance;
+    if (instance == null) {
+      throw new OneOpsClientAPIException("Missing OneOps instance information to perform API invocation");
+    }
+    if (instance.getAuthtoken() == null) {
+      throw new OneOpsClientAPIException("Missing OneOps authentication API key to perform API invocation");
+    }
+    if (instance.getEndpoint() == null) {
+      throw new OneOpsClientAPIException("Missing OneOps endpoint to perform API invocation");
+    }
+  }
+
+  protected RequestSpecification createRequest() {
+    RequestSpecification rs = RestAssured.given();
+    String basicAuth = "Basic " + new String(Base64.encodeBase64(instance.getAuthtoken().getBytes()));
+    rs.header("Authorization", basicAuth);
+    rs.header("User-Agent", "OneOpsAPIClient");
+    rs.header("Accept", "application/json");
+    rs.header("Content-Type", "application/json");
+    String baseUri = instance.getEndpoint();
+    if (instance.getOrgname() != null) {
+      baseUri += instance.getOrgname();
+    }
+    rs.baseUri(baseUri);
+    rs.config(RestAssured.config().sslConfig(new SSLConfig().relaxedHTTPSValidation()));
+    return rs;
+  }
+
+  // Account
+
+  /**
+   * Lists all the organizations
+   * 
+   * @return
+   * @throws OneOpsClientAPIException
+   */
+  public List<Organization> listOrganizations() throws OneOpsClientAPIException {
+    RequestSpecification request = createRequest();
+    Response response = request.get(IConstants.ACCOUNT_URI);
+    if (response != null) {
+      if (response.getStatusCode() == 200 || response.getStatusCode() == 302) {
+        return JsonUtil.toObject(response.getBody().asString(), new TypeReference<List<Organization>>() {});
+      } else {
+        String msg = String.format("Failed to get list of organizations due to %s", response.getStatusLine());
+        throw new OneOpsClientAPIException(msg);
+      }
+    }
+    String msg = "Failed to get list of organizations due to null response";
+    throw new OneOpsClientAPIException(msg);
+  }
+
+  /**
+   * Fetches specific organization details
+   * 
+   * @param organizationName
+   * @return
+   * @throws OneOpsClientAPIException
+   */
+  public Organization getOrganization(String organizationName) throws OneOpsClientAPIException {
+    if (organizationName == null || organizationName.length() == 0) {
+      String msg = "Missing organization name to fetch details";
+      throw new OneOpsClientAPIException(msg);
+    }
+
+    RequestSpecification request = createRequest();
+    Response response = request.get(IConstants.ACCOUNT_URI + organizationName);
+    if (response != null) {
+      if (response.getStatusCode() == 200 || response.getStatusCode() == 302) {
+        return response.getBody().as(Organization.class);
+      } else {
+        String msg = String.format("Failed to get organization with name %s due to %s", organizationName, response.getStatusLine());
+        throw new OneOpsClientAPIException(msg);
+      }
+    }
+    String msg = String.format("Failed to get organization with name %s due to null response", organizationName);
+    throw new OneOpsClientAPIException(msg);
+  }
+
+  /**
+   * Creates organization for the given @organizationName
+   * 
+   * @param organizationName {mandatory} 
+   * @return
+   * @throws OneOpsClientAPIException
+   */
+  public Organization createOrganization(String organizationName) throws OneOpsClientAPIException {
+    if (organizationName == null || organizationName.length() == 0) {
+      String msg = "Missing organization name to create one";
+      throw new OneOpsClientAPIException(msg);
+    }
+    RequestSpecification request = createRequest();
+    JSONObject jsonObject = new JSONObject();
+    jsonObject.put("name", organizationName);
+    Response response = request.body(jsonObject.toString()).post(IConstants.ACCOUNT_URI);
+
+    if (response != null) {
+      if (response.getStatusCode() == 200 || response.getStatusCode() == 302) {
+        return response.getBody().as(Organization.class);
+      } else {
+        String msg = String.format("Failed to create organization with name %s due to %s", organizationName, response.getStatusLine());
+        throw new OneOpsClientAPIException(msg);
+      }
+    }
+    String msg = String.format("Failed to create organization with name %s due to null response", organizationName);
+    throw new OneOpsClientAPIException(msg);
+  }
+
+  /**
+   * Deletes the given organization
+   * 
+   * @param organizationName
+   * @return
+   * @throws OneOpsClientAPIException
+   */
+  public Organization deleteOrganization(String organizationName) throws OneOpsClientAPIException {
+    if (organizationName == null || organizationName.length() == 0) {
+      String msg = "Missing organization name to delete one";
+      throw new OneOpsClientAPIException(msg);
+    }
+
+    RequestSpecification request = createRequest();
+    Organization org = getOrganization(organizationName);
+    Long id = org.getId();
+    if (id == null) {
+      String msg = String.format("Failed to find organization with name %s to delete", organizationName);
+      throw new OneOpsClientAPIException(msg);
+    }
+
+    Response response = request.delete(IConstants.ACCOUNT_URI + id);
+    if (response != null) {
+      if (response.getStatusCode() == 200 || response.getStatusCode() == 302) {
+        return response.getBody().as(Organization.class);
+      } else {
+        String msg = String.format("Failed to delete organization with name %s due to %s", organizationName, response.getStatusLine());
+        throw new OneOpsClientAPIException(msg);
+      }
+    }
+    String msg = String.format("Failed to delete organization with name %s due to null response", organizationName);
+    throw new OneOpsClientAPIException(msg);
+  }
+
+  /**
+   * Lists all the Environment Profiles
+   * 
+   * @return
+   * @throws OneOpsClientAPIException
+   */
+  public JsonPath listEnvironmentProfiles() throws OneOpsClientAPIException {
+    RequestSpecification request = createRequest();
+    Response response = request.get(IConstants.ORGANIZATION_URI + "environments");
+    if (response != null) {
+      if (response.getStatusCode() == 200 || response.getStatusCode() == 302) {
+        System.out.println(response.getBody().asString());
+        return response.getBody().jsonPath();
+      } else {
+        String msg = String.format("Failed to get list of Environment Profiles due to %s", response.getStatusLine());
+        throw new OneOpsClientAPIException(msg);
+      }
+    }
+    String msg = "Failed to get list of Environment Profiles due to null response";
+    throw new OneOpsClientAPIException(msg);
+  }
+
+  // Assembly
+
+  /**
+   * Fetches specific assembly details
+   * 
+   * @param assemblyName
+   * @return
+   * @throws OneOpsClientAPIException
+   */
+  public CiResource getAssembly(String assemblyName) throws OneOpsClientAPIException {
+    if (assemblyName == null || assemblyName.length() == 0) {
+      String msg = "Missing assembly name to fetch details";
+      throw new OneOpsClientAPIException(msg);
+    }
+
+    RequestSpecification request = createRequest();
+    Response response = request.get(IConstants.ASSEMBLY_URI + assemblyName);
+    if (response != null) {
+      if (response.getStatusCode() == 200 || response.getStatusCode() == 302) {
+        return response.getBody().as(CiResource.class);
+      } else {
+        String msg = String.format("Failed to get assembly with name %s due to %s", assemblyName, response.getStatusLine());
+        throw new OneOpsClientAPIException(msg);
+      }
+    }
+    String msg = String.format("Failed to get assembly with name %s due to null response", assemblyName);
+    throw new OneOpsClientAPIException(msg);
+  }
+
+  /**
+   * Lists all the assemblies
+   * 
+   * @return
+   * @throws OneOpsClientAPIException
+   */
+  public List<CiResource> listAssemblies() throws OneOpsClientAPIException {
+    RequestSpecification request = createRequest();
+    Response response = request.get(IConstants.ASSEMBLY_URI);
+    if (response != null) {
+      if (response.getStatusCode() == 200 || response.getStatusCode() == 302) {
+        return JsonUtil.toObject(response.getBody().asString(), new TypeReference<List<CiResource>>() {});
+      } else {
+        String msg = String.format("Failed to get list of assemblies due to %s", response.getStatusLine());
+        throw new OneOpsClientAPIException(msg);
+      }
+    }
+    String msg = "Failed to get list of assemblies due to null response";
+    throw new OneOpsClientAPIException(msg);
+  }
+
+
+  /**
+   * Creates assembly for the given @assemblyName
+   * 
+   * @param assemblyName {mandatory} 
+   * @param ownerEmail a valid email address is {mandatory}
+   * @param comments
+   * @param description
+   * @return
+   * @throws OneOpsClientAPIException
+   */
+  public CiResource createAssembly(String assemblyName, String ownerEmail, String comments, String description) throws OneOpsClientAPIException {
+    return createAssembly(assemblyName, ownerEmail, comments, description, null);
+  }
+
+  /**
+   * Creates assembly for the given @assemblyName
+   * 
+   * @param assemblyName {mandatory} 
+   * @param ownerEmail a valid email address is {mandatory}
+   * @param comments
+   * @param description
+   * @param tags
+   * @return
+   * @throws OneOpsClientAPIException
+   */
+  public CiResource createAssembly(String assemblyName, String ownerEmail, String comments, String description, Map<String, String> tags) throws OneOpsClientAPIException {
+    ResourceObject ro = new ResourceObject();
+    Map<String, String> attributes = new HashMap<String, String>();
+    Map<String, String> properties = new HashMap<String, String>();
+
+    if (assemblyName != null && assemblyName.length() > 0) {
+      properties.put("ciName", assemblyName);
+    } else {
+      String msg = "Missing assembly name to create one";
+      throw new OneOpsClientAPIException(msg);
+    }
+
+    properties.put("comments", comments);
+    ro.setProperties(properties);
+
+    if (ownerEmail != null && ownerEmail.length() > 0) {
+      attributes.put("owner", ownerEmail);
+    } else {
+      String msg = "Missing assembly owner email address";
+      throw new OneOpsClientAPIException(msg);
+    }
+
+    attributes.put("description", description);
+
+    if (tags != null && !tags.isEmpty()) {
+      attributes.put("tags", JSONObject.valueToString(tags));
+    }
+
+    ro.setAttributes(attributes);
+
+    RequestSpecification request = createRequest();
+    JSONObject jsonObject = JsonUtil.createJsonObject(ro, "cms_ci");
+
+    Response response = request.body(jsonObject.toString()).post(IConstants.ASSEMBLY_URI);
+
+    if (response != null) {
+      if (response.getStatusCode() == 200 || response.getStatusCode() == 302) {
+        return response.getBody().as(CiResource.class);
+      } else {
+        String msg = String.format("Failed to create assembly with name %s due to %s", assemblyName, response.getStatusLine());
+        throw new OneOpsClientAPIException(msg);
+      }
+    }
+    String msg = String.format("Failed to create assembly with name %s due to null response", assemblyName);
+    throw new OneOpsClientAPIException(msg);
+  }
+
+  /**
+   * Updates assembly for the given @assemblyName
+   * 
+   * @param assemblyName {mandatory} 
+   * @param ownerEmail a valid email address is {mandatory}
+   * @param description
+   * @param tags
+   * @return
+   * @throws OneOpsClientAPIException
+   */
+  public CiResource updateAssembly(String assemblyName, String ownerEmail, String description, Map<String, String> tags) throws OneOpsClientAPIException {
+    ResourceObject ro = new ResourceObject();
+    Map<String, String> attributes = new HashMap<String, String>();
+    Map<String, String> properties = new HashMap<String, String>();
+
+    if (assemblyName != null && assemblyName.length() > 0) {
+      properties.put("ciName", assemblyName);
+    } else {
+      String msg = "Missing assembly name to update one";
+      throw new OneOpsClientAPIException(msg);
+    }
+
+    CiResource assembly = getAssembly(assemblyName);
+
+    properties.put("ciId", String.valueOf(assembly.getCiId()));
+    ro.setProperties(properties);
+
+    if (ownerEmail != null && ownerEmail.length() > 0) {
+      attributes.put("owner", ownerEmail);
+    }
+
+    if (description != null && description.length() > 0) {
+      attributes.put("description", description);
+    }
+
+    if (tags != null && !tags.isEmpty()) {
+      attributes.put("tags", JSONObject.valueToString(tags));
+    }
+
+    ro.setAttributes(attributes);
+
+    RequestSpecification request = createRequest();
+    JSONObject jsonObject = JsonUtil.createJsonObject(ro, "cms_ci");
+
+    Response response = request.body(jsonObject.toString()).put(IConstants.ASSEMBLY_URI + assemblyName);
+
+    if (response != null) {
+      if (response.getStatusCode() == 200 || response.getStatusCode() == 302) {
+        return response.getBody().as(CiResource.class);
+      } else {
+        String msg = String.format("Failed to update assembly with name %s due to %s", assemblyName, response.getStatusLine());
+        throw new OneOpsClientAPIException(msg);
+      }
+    }
+    String msg = String.format("Failed to update assembly with name %s due to null response", assemblyName);
+    throw new OneOpsClientAPIException(msg);
+  }
+
+  /**
+   * Deletes the given assembly
+   * 
+   * @param assemblyName
+   * @return
+   * @throws OneOpsClientAPIException
+   */
+  public CiResource deleteAssembly(String assemblyName) throws OneOpsClientAPIException {
+    if (assemblyName == null || assemblyName.length() == 0) {
+      String msg = "Missing assembly name to delete one";
+      throw new OneOpsClientAPIException(msg);
+    }
+
+    RequestSpecification request = createRequest();
+    Response response = request.delete(IConstants.ASSEMBLY_URI + assemblyName);
+    if (response != null) {
+      if (response.getStatusCode() == 200 || response.getStatusCode() == 302) {
+        return response.getBody().as(CiResource.class);
+      } else {
+        String msg = String.format("Failed to delete assembly with name %s due to %s", assemblyName, response.getStatusLine());
+        throw new OneOpsClientAPIException(msg);
+      }
+    }
+    String msg = String.format("Failed to delete assembly with name %s due to null response", assemblyName);
+    throw new OneOpsClientAPIException(msg);
+  }
+
+  // Cloud
+
+  /**
+   * Fetches specific cloud details
+   * 
+   * @param cloudName
+   * @return
+   * @throws OneOpsClientAPIException
+   */
+  public CiResource getCloud(String cloudName) throws OneOpsClientAPIException {
+    if (cloudName == null || cloudName.length() == 0) {
+      String msg = "Missing cloud name to fetch details";
+      throw new OneOpsClientAPIException(msg);
+    }
+
+    RequestSpecification request = createRequest();
+    Response response = request.get(IConstants.CLOUDS_URI + cloudName);
+    if (response != null) {
+      if (response.getStatusCode() == 200 || response.getStatusCode() == 302) {
+        return response.getBody().as(CiResource.class);
+      } else {
+        String msg = String.format("Failed to get cloud with name %s due to %s", cloudName, response.getStatusLine());
+        throw new OneOpsClientAPIException(msg);
+      }
+    }
+    String msg = String.format("Failed to get cloud with name %s due to null response", cloudName);
+    throw new OneOpsClientAPIException(msg);
+  }
+
+  /**
+   * Lists all the clouds
+   * 
+   * @return
+   * @throws OneOpsClientAPIException
+   */
+  public List<CiResource> listClouds() throws OneOpsClientAPIException {
+    RequestSpecification request = createRequest();
+    Response response = request.get(IConstants.CLOUDS_URI);
+    if (response != null) {
+      if (response.getStatusCode() == 200 || response.getStatusCode() == 302) {
+        return JsonUtil.toObject(response.getBody().asString(), new TypeReference<List<CiResource>>() {});
+      } else {
+        String msg = String.format("Failed to get list of clouds due to %s", response.getStatusLine());
+        throw new OneOpsClientAPIException(msg);
+      }
+    }
+    String msg = "Failed to get list of clouds due to null response";
+    throw new OneOpsClientAPIException(msg);
+  }
+
+  /**
+   * Lists cloud variables given the cloudName
+   *
+   * @param cloudName
+   * @return
+   * @throws OneOpsClientAPIException
+   */
+  public List<CiResource> listCloudVariables(String cloudName) throws OneOpsClientAPIException {
+    if (cloudName == null || cloudName.length() == 0) {
+      String msg = "Missing cloud name to list cloud variables";
+      throw new OneOpsClientAPIException(msg);
+    }
+
+    RequestSpecification request = createRequest();
+    Response response = request.get(IConstants.CLOUDS_URI + cloudName + IConstants.VARIABLES_URI);
+    if (response != null) {
+      if (response.getStatusCode() == 200 || response.getStatusCode() == 302) {
+        return JsonUtil.toObject(response.getBody().asString(), new TypeReference<List<CiResource>>() {});
+      } else {
+        String msg = String.format("Failed to get list of cloud variables due to %s", response.getStatusLine());
+        throw new OneOpsClientAPIException(msg);
+      }
+    }
+    String msg = "Failed to get list of cloud variables due to null response";
+    throw new OneOpsClientAPIException(msg);
+  }  
+  
+  // Design
+
+  /**
+   * Fetches specific platform details
+   * 
+   * @param platformName
+   * @return
+   * @throws OneOpsClientAPIException
+   */
+  public CiResource getPlatform(String assemblyName, String platformName) throws OneOpsClientAPIException {
+    if (platformName == null || platformName.length() == 0) {
+      String msg = "Missing platform name to fetch details";
+      throw new OneOpsClientAPIException(msg);
+    }
+
+    RequestSpecification request = createRequest();
+    Response response = request.get(designURI(assemblyName) + IConstants.PLATFORM_URI + platformName);
+    if (response != null) {
+      if (response.getStatusCode() == 200 || response.getStatusCode() == 302) {
+        return response.getBody().as(CiResource.class);
+      } else {
+        String msg = String.format("Failed to get platform with name %s due to %s", platformName, response.getStatusLine());
+        throw new OneOpsClientAPIException(msg);
+      }
+    }
+    String msg = String.format("Failed to get platform with name %s due to null response", platformName);
+    throw new OneOpsClientAPIException(msg);
+  }
+
+  /**
+   * Lists all the platforms
+   * 
+   * @return
+   * @throws OneOpsClientAPIException
+   */
+  public List<CiResource> listPlatforms(String assemblyName) throws OneOpsClientAPIException {
+    RequestSpecification request = createRequest();
+    Response response = request.get(designURI(assemblyName) + IConstants.PLATFORM_URI);
+    if (response != null) {
+      if (response.getStatusCode() == 200 || response.getStatusCode() == 302) {
+        return JsonUtil.toObject(response.getBody().asString(), new TypeReference<List<CiResource>>() {});
+      } else {
+        String msg = String.format("Failed to get list of platforms due to %s", response.getStatusLine());
+        throw new OneOpsClientAPIException(msg);
+      }
+    }
+    String msg = "Failed to get list of platforms due to null response";
+    throw new OneOpsClientAPIException(msg);
+  }
+
+
+  /**
+   * Creates platform within the given assembly
+   * 
+   * @param platformName {mandatory}
+   * @param packname {mandatory}
+   * @param packversion {mandatory}
+   * @param packsource {mandatory}
+   * @param comments
+   * @param description
+   * @return
+   * @throws OneOpsClientAPIException
+   */
+  public CiResource createPlatform(String assemblyName, String platformName, String packname, String packversion,
+    String packsource, String comments, String description) throws OneOpsClientAPIException {
+
+    ResourceObject ro = new ResourceObject();
+    Map<String, String> attributes = new HashMap<String, String>();
+    Map<String, String> properties = new HashMap<String, String>();
+
+    if (platformName != null && platformName.length() > 0) {
+      properties.put("ciName", platformName);
+    } else {
+      String msg = "Missing platform name to create platform";
+      throw new OneOpsClientAPIException(msg);
+    }
+
+    if (packname != null && packname.length() > 0) {
+      attributes.put("pack", packname);
+    } else {
+      String msg = "Missing pack name to create platform";
+      throw new OneOpsClientAPIException(msg);
+    }
+
+    if (packversion != null && packversion.length() > 0) {
+      attributes.put("version", packversion);
+    } else {
+      String msg = "Missing pack version to create platform";
+      throw new OneOpsClientAPIException(msg);
+    }
+
+    if (packsource != null && packsource.length() > 0) {
+      attributes.put("source", packsource);
+    } else {
+      String msg = "Missing platform name to create platform";
+      throw new OneOpsClientAPIException(msg);
+    }
+    attributes.put("major_version", "1");
+
+    properties.put("comments", comments);
+    ro.setProperties(properties);
+
+    attributes.put("description", description);
+    ro.setAttributes(attributes);
+
+    Map<String, String> ownerProps = Maps.newHashMap();
+    ownerProps.put("description", "");
+    ro.setOwnerProps(ownerProps);
+    RequestSpecification request = createRequest();
+    JSONObject jsonObject = JsonUtil.createJsonObject(ro, "cms_dj_ci");
+    Response response = request.body(jsonObject.toString()).post(designURI(assemblyName) + IConstants.PLATFORM_URI);
+
+    if (response != null) {
+      if (response.getStatusCode() == 200 || response.getStatusCode() == 302) {
+        return response.getBody().as(CiResource.class);
+      } else {
+        String msg = String.format("Failed to create platform with name %s due to %s", platformName, response.getStatusLine());
+        throw new OneOpsClientAPIException(msg);
+      }
+    }
+    String msg = String.format("Failed to create platform with name %s due to null response", platformName);
+    throw new OneOpsClientAPIException(msg);
+  }
+
+
+
+  /**
+   * Commits design open releases
+   * 
+   * @return
+   * @throws OneOpsClientAPIException
+   */
+  public Release commitDesign(String assemblyName) throws OneOpsClientAPIException {
+    RequestSpecification request = createRequest();
+    Response response = request.get(designReleaseURI(assemblyName) + "latest");
+    if (response != null) {
+      if (response.getStatusCode() == 200 || response.getStatusCode() == 302) {
+
+        String releaseState = response.getBody().jsonPath().get("releaseState");
+        if ("open".equals(releaseState)) {
+          int releaseId = response.getBody().jsonPath().get("releaseId");
+          response = request.post(designReleaseURI(assemblyName) + releaseId + "/commit");
+          if (response.getStatusCode() == 200 || response.getStatusCode() == 302) {
+            return response.getBody().as(Release.class);
+          } else {
+            String msg = String.format("Failed to commit design due to %s", response.getStatusLine());
+            throw new OneOpsClientAPIException(msg);
+          }
+        } else {
+          String msg = String.format("No open release found to perform design commit");
+          throw new OneOpsClientAPIException(msg);
+        }
+
+      } else {
+        String msg = String.format("Failed to get latest release details due to %s", response.getStatusLine());
+        throw new OneOpsClientAPIException(msg);
+      }
+    }
+    String msg = "Failed to commit design due to null response";
+    throw new OneOpsClientAPIException(msg);
+  }
+
+
+  /**
+   * Commits specific platform with open release
+   * 
+   * @return
+   * @throws OneOpsClientAPIException
+   */
+  public JsonPath commitPlatform(String assemblyName, String platformName) throws OneOpsClientAPIException {
+
+    RequestSpecification request = createRequest();
+    CiResource platform = getPlatform(assemblyName, platformName);
+    if (platform != null) {
+      Long platformId = platform.getCiId();
+      Response response = request.post(designURI(assemblyName) + IConstants.PLATFORM_URI + platformId + "/commit");
+      if (response.getStatusCode() == 200 || response.getStatusCode() == 302) {
+        return response.getBody().jsonPath();
+      } else {
+        String msg = String.format("Failed to commit %s platform due to %s", platformName, response.getStatusLine());
+        throw new OneOpsClientAPIException(msg);
+      }
+
+    }
+    String msg = String.format("Failed to commit %s due to null response", platformName);
+    throw new OneOpsClientAPIException(msg);
+  }
+
+  public CiResource updatePlatformLinks(String assemblyName, String fromPlatformName, List<String> toPlatformNames) throws OneOpsClientAPIException {
+    if (fromPlatformName == null || fromPlatformName.length() == 0) {
+      String msg = "Missing from platform name to link";
+      throw new OneOpsClientAPIException(msg);
+    }
+    if (toPlatformNames == null || toPlatformNames.size() == 0) {
+      String msg = "Missing to platform name to link";
+      throw new OneOpsClientAPIException(msg);
+    }
+
+    List<Long> toIds = new ArrayList<Long>();
+    for (String toPlatformName : toPlatformNames) {
+      CiResource toPlatform = getPlatform(assemblyName, toPlatformName);
+      toIds.add(toPlatform.getCiId());
+    }
+
+    CiResource fromPlatform = getPlatform(assemblyName, fromPlatformName);
+
+    ResourceObject ro = new ResourceObject();
+    Map<String, String> properties = new HashMap<String, String>();
+    properties.put("ciId", fromPlatform.getCiId() + "");
+    ro.setProperties(properties);
+    JSONObject jsonObject = JsonUtil.createJsonObject(ro, "cms_dj_ci");
+    jsonObject.put("links_to", toIds);
+
+    RequestSpecification request = createRequest();
+    Response response = request.body(jsonObject.toString()).put(designURI(assemblyName) + IConstants.PLATFORM_URI + fromPlatform.getCiId());
+
+    if (response != null) {
+      if (response.getStatusCode() == 200 || response.getStatusCode() == 302) {
+        return response.getBody().as(CiResource.class);
+      } else {
+        String msg = String.format("Failed to update platform link to %s from %s due to %s response", toPlatformNames, fromPlatformName, response.getStatusLine());
+        throw new OneOpsClientAPIException(msg);
+      }
+    }
+
+    String msg = String.format("Failed to update platform link to %s from %s due to null response", toPlatformNames, fromPlatformName);
+    throw new OneOpsClientAPIException(msg);
+  }
+
+  /**
+   * Deletes the given platform
+   * 
+   * @param platformName
+   * @return
+   * @throws OneOpsClientAPIException
+   */
+  public CiResource deletePlatform(String assemblyName, String platformName) throws OneOpsClientAPIException {
+    if (platformName == null || platformName.length() == 0) {
+      String msg = "Missing platform name to delete";
+      throw new OneOpsClientAPIException(msg);
+    }
+
+    RequestSpecification request = createRequest();
+    Response response = request.delete(designURI(assemblyName) + IConstants.PLATFORM_URI + platformName);
+    if (response != null) {
+      if (response.getStatusCode() == 200 || response.getStatusCode() == 302) {
+        return response.getBody().as(CiResource.class);
+      } else {
+        String msg = String.format("Failed to delete platform with name %s due to %s", platformName, response.getStatusLine());
+        throw new OneOpsClientAPIException(msg);
+      }
+    }
+    String msg = String.format("Failed to delete platform with name %s due to null response", platformName);
+    throw new OneOpsClientAPIException(msg);
+  }
+
+  /**
+   * List platform components for a given assembly/design/platform
+   * 
+   * @param environmentName
+   * @param platformName
+   * @return
+   * @throws OneOpsClientAPIException
+   */
+  public List<CiResource> listPlatformComponents(String assemblyName, String platformName) throws OneOpsClientAPIException {
+    if (platformName == null || platformName.length() == 0) {
+      String msg = "Missing platform name to list enviornment platform components";
+      throw new OneOpsClientAPIException(msg);
+    }
+    RequestSpecification request = createRequest();
+    Response response = request.get(designURI(assemblyName) + IConstants.PLATFORM_URI + platformName + IConstants.COMPONENT_URI);
+    if (response != null) {
+      if (response.getStatusCode() == 200 || response.getStatusCode() == 302) {
+        return JsonUtil.toObject(response.getBody().asString(), new TypeReference<List<CiResource>>() {});
+      } else {
+        String msg = String.format("Failed to get list of platforms components due to %s", response.getStatusLine());
+        throw new OneOpsClientAPIException(msg);
+      }
+    }
+    String msg = "Failed to get list of platforms components due to null response";
+    throw new OneOpsClientAPIException(msg);
+  }
+
+  /**
+   * Get platform component details for a given assembly/design/platform
+   * 
+   * @param platformName
+   * @param componentName
+   * @return
+   * @throws OneOpsClientAPIException
+   */
+  public CiResource getPlatformComponent(String assemblyName, String platformName, String componentName) throws OneOpsClientAPIException {
+    if (platformName == null || platformName.length() == 0) {
+      String msg = "Missing platform name to get platform component details";
+      throw new OneOpsClientAPIException(msg);
+    }
+    if (componentName == null || componentName.length() == 0) {
+      String msg = "Missing component name to get platform component details";
+      throw new OneOpsClientAPIException(msg);
+    }
+    RequestSpecification request = createRequest();
+    Response response = request.get(designURI(assemblyName) + IConstants.PLATFORM_URI + platformName + IConstants.COMPONENT_URI + componentName);
+    if (response != null) {
+      if (response.getStatusCode() == 200 || response.getStatusCode() == 302) {
+        return response.getBody().as(CiResource.class);
+      } else {
+        String msg = String.format("Failed to get platform component details due to %s", response.getStatusLine());
+        throw new OneOpsClientAPIException(msg);
+      }
+    }
+    String msg = "Failed to get platform component details due to null response";
+    throw new OneOpsClientAPIException(msg);
+  }
+
+  /**
+   * Add component to a given assembly/design/platform
+   * 
+   * @param platformName
+   * @param componentName
+   * @param attributes
+   * @return
+   * @throws OneOpsClientAPIException
+   */
+  public CiResource addPlatformComponent(String assemblyName, String platformName, String componentName, String uniqueName, Map<String, String> attributes) throws OneOpsClientAPIException {
+    if (platformName == null || platformName.length() == 0) {
+      String msg = "Missing platform name to add component";
+      throw new OneOpsClientAPIException(msg);
+    }
+    if (componentName == null || componentName.length() == 0) {
+      String msg = "Missing component name to add component";
+      throw new OneOpsClientAPIException(msg);
+    }
+
+    RequestSpecification request = createRequest();
+
+    Response newComponentResponse = request.queryParam("template_name", componentName).get(designURI(assemblyName) + IConstants.PLATFORM_URI + platformName + IConstants.COMPONENT_URI + "new.json");
+    if (newComponentResponse != null) {
+      ResourceObject ro = new ResourceObject();
+      Map<String, String> properties = Maps.newHashMap();
+      properties.put("ciName", uniqueName);
+      properties.put("rfcAction", "add");
+
+      JsonPath componentDetails = newComponentResponse.getBody().jsonPath();
+      Map<String, String> attr = componentDetails.getMap("ciAttributes");
+      if (attr == null) {
+        attr = Maps.newHashMap();
+      }
+      if (attributes != null && attributes.size() > 0) {
+        attr.putAll(attributes);
+
+        Map<String, String> ownerProps = componentDetails.getMap("ciAttrProps.owner");
+        if (ownerProps == null) {
+          ownerProps = Maps.newHashMap();
+        }
+        for (Entry<String, String> entry : attributes.entrySet()) {
+          ownerProps.put(entry.getKey(), "design");
+        }
+        ro.setOwnerProps(ownerProps);
+      }
+      ro.setAttributes(attr);
+      ro.setProperties(properties);
+      JSONObject jsonObject = JsonUtil.createJsonObject(ro, "cms_dj_ci");
+      jsonObject.put("template_name", componentName);
+      Response response = request.body(jsonObject.toString()).post(designURI(assemblyName) + IConstants.PLATFORM_URI + platformName + IConstants.COMPONENT_URI);
+      if (response != null) {
+        if (response.getStatusCode() == 200 || response.getStatusCode() == 302) {
+          return response.getBody().as(CiResource.class);
+        } else {
+          String msg = String.format("Failed to get add component %s due to %s", componentName, response.getStatusLine());
+          throw new OneOpsClientAPIException(msg);
+        }
+      }
+    }
+
+    String msg = String.format("Failed to get add component %s due to null response", componentName);
+    throw new OneOpsClientAPIException(msg);
+  }
+
+  /**
+   * Update component attributes for a given assembly/design/platform/component
+   * 
+   * @param platformName
+   * @param componentName
+   * @param attributes
+   * @return
+   * @throws OneOpsClientAPIException
+   */
+  public CiResource updatePlatformComponent(String assemblyName, String platformName, String componentName, Map<String, String> attributes) throws OneOpsClientAPIException {
+    if (platformName == null || platformName.length() == 0) {
+      String msg = "Missing platform name to update component attributes";
+      throw new OneOpsClientAPIException(msg);
+    }
+    if (componentName == null || componentName.length() == 0) {
+      String msg = "Missing component name to update component attributes";
+      throw new OneOpsClientAPIException(msg);
+    }
+    if (attributes == null || attributes.size() == 0) {
+      String msg = "Missing attributes list to be updated";
+      throw new OneOpsClientAPIException(msg);
+    }
+
+    CiResource componentDetails = getPlatformComponent(assemblyName, platformName, componentName);
+    if (componentDetails != null) {
+      ResourceObject ro = new ResourceObject();
+
+      Long ciId = componentDetails.getCiId();
+      RequestSpecification request = createRequest();
+
+      Map<String, String> attr = Maps.newHashMap();
+      //Add ciAttributes to be updated
+      if (attributes != null && attributes.size() > 0)
+        attr.putAll(attributes);
+
+      Map<String, String> ownerProps = Maps.newHashMap();
+      //Add existing attrProps to retain locking of attributes 
+      AttrProps attrProps = componentDetails.getAttrProps();
+      if (attrProps != null && attrProps.getAdditionalProperties() != null && attrProps.getAdditionalProperties().size() > 0 && attrProps.getAdditionalProperties().get("owner") != null) {
+        Map<String, String> ownersMap = (Map<String, String>) attrProps.getAdditionalProperties().get("owner");
+        for (Entry<String, String> entry : ownersMap.entrySet()) {
+          ownerProps.put(entry.getKey(), entry.getValue());
+        }
+      }
+
+      //Add updated attributes to attrProps to lock them
+      for (Entry<String, String> entry : attributes.entrySet()) {
+        ownerProps.put(entry.getKey(), "design");
+      }
+
+      ro.setOwnerProps(ownerProps);
+      ro.setAttributes(attr);
+      JSONObject jsonObject = JsonUtil.createJsonObject(ro, "cms_dj_ci");
+      Response response = request.body(jsonObject.toString()).put(designURI(assemblyName) + IConstants.PLATFORM_URI + platformName + IConstants.COMPONENT_URI + ciId);
+      if (response != null) {
+        if (response.getStatusCode() == 200 || response.getStatusCode() == 302) {
+          return response.getBody().as(CiResource.class);
+        } else {
+          String msg = String.format("Failed to get update component %s due to %s", componentName, response.getStatusLine());
+          throw new OneOpsClientAPIException(msg);
+        }
+      }
+    }
+    String msg = String.format("Failed to get update component %s due to null response", componentName);
+    throw new OneOpsClientAPIException(msg);
+  }
+
+  /**
+   * Deletes the given platform component
+   * 
+   * @param platformName
+   * @param componentName
+   * @return
+   * @throws OneOpsClientAPIException
+   */
+  public CiResource deletePlatformComponent(String assemblyName, String platformName, String componentName) throws OneOpsClientAPIException {
+    if (platformName == null || platformName.length() == 0) {
+      String msg = "Missing platform name to delete component";
+      throw new OneOpsClientAPIException(msg);
+    }
+    if (componentName == null || componentName.length() == 0) {
+      String msg = "Missing component name to delete it";
+      throw new OneOpsClientAPIException(msg);
+    }
+
+    RequestSpecification request = createRequest();
+    Response response = request.delete(designURI(assemblyName) + IConstants.PLATFORM_URI + platformName + IConstants.COMPONENT_URI + componentName);
+    if (response != null) {
+      if (response.getStatusCode() == 200 || response.getStatusCode() == 302) {
+        return response.getBody().as(CiResource.class);
+      } else {
+        String msg = String.format("Failed to delete platform with name %s due to %s", platformName, response.getStatusLine());
+        throw new OneOpsClientAPIException(msg);
+      }
+    }
+    String msg = String.format("Failed to delete platform with name %s due to null response", platformName);
+    throw new OneOpsClientAPIException(msg);
+  }
+
+  /**
+   * List attachments for a given assembly/design/platform/component
+   * 
+   * @param platformName
+   * @return
+   * @throws OneOpsClientAPIException
+   */
+  public List<CiResource> listPlatformComponentAttachments(String assemblyName, String platformName, String componentName) throws OneOpsClientAPIException {
+    if (platformName == null || platformName.length() == 0) {
+      String msg = "Missing platform name to list platform attachments";
+      throw new OneOpsClientAPIException(msg);
+    }
+    RequestSpecification request = createRequest();
+    Response response = request.get(designURI(assemblyName) + IConstants.PLATFORM_URI + platformName + IConstants.COMPONENT_URI + componentName + IConstants.ATTACHMENTS_URI);
+    if (response != null) {
+      if (response.getStatusCode() == 200 || response.getStatusCode() == 302) {
+        return JsonUtil.toObject(response.getBody().asString(), new TypeReference<List<CiResource>>() {});
+      } else {
+        String msg = String.format("Failed to get list of design platforms attachments due to %s", response.getStatusLine());
+        throw new OneOpsClientAPIException(msg);
+      }
+    }
+    String msg = "Failed to get list of design platforms attachments due to null response";
+    throw new OneOpsClientAPIException(msg);
+  }
+
+  /**
+   * Get platform component attachment details 
+   * 
+   * @param platformName
+   * @param componentName
+   * @return
+   * @throws OneOpsClientAPIException
+   */
+  public CiResource getPlatformComponentAttachment(String assemblyName, String platformName, String componentName, String attachmentName) throws OneOpsClientAPIException {
+    if (platformName == null || platformName.length() == 0) {
+      String msg = "Missing platform name to get platform component attachment details";
+      throw new OneOpsClientAPIException(msg);
+    }
+    if (componentName == null || componentName.length() == 0) {
+      String msg = "Missing component name to get platform component attachment details";
+      throw new OneOpsClientAPIException(msg);
+    }
+    RequestSpecification request = createRequest();
+    Response response = request.get(designURI(assemblyName) + IConstants.PLATFORM_URI + platformName + IConstants.COMPONENT_URI + componentName + IConstants.ATTACHMENTS_URI + attachmentName);
+    if (response != null) {
+      if (response.getStatusCode() == 200 || response.getStatusCode() == 302) {
+        return response.getBody().as(CiResource.class);
+      } else {
+        String msg = String.format("Failed to get platform component attachment details due to %s", response.getStatusLine());
+        throw new OneOpsClientAPIException(msg);
+      }
+    }
+    String msg = "Failed to get platform component attachment details due to null response";
+    throw new OneOpsClientAPIException(msg);
+  }
+
+  /**
+   * Update attachment
+   * 
+   * @param platformName
+   * @param componentName
+   * @param attachmentName
+   * @param attributes
+   * 
+   *  Sample request for new attachment attributes
+   *  attributes.put("content", "content");
+    attributes.put("source", "source");
+    attributes.put("path", "/tmp/my.sh");
+    attributes.put("exec_cmd", "exec_cmd");
+    attributes.put("run_on", "after-add,after-replace,after-update");
+    attributes.put("run_on_action", "[\"after-restart\"]");
+    
+   * @return
+   * @throws OneOpsClientAPIException
+   */
+  public CiResource updatePlatformComponentAttachment(String assemblyName, String platformName, String componentName, String attachmentName, Map<String, String> attributes)
+    throws OneOpsClientAPIException {
+    if (platformName == null || platformName.length() == 0) {
+      String msg = "Missing platform name to update attachment attributes";
+      throw new OneOpsClientAPIException(msg);
+    }
+    if (componentName == null || componentName.length() == 0) {
+      String msg = "Missing component name to update attachment attributes";
+      throw new OneOpsClientAPIException(msg);
+    }
+    if (attachmentName == null || attachmentName.length() == 0) {
+      String msg = "Missing attachment name to update attachment attributes";
+      throw new OneOpsClientAPIException(msg);
+    }
+    if (attributes == null || attributes.size() == 0) {
+      //nothing to be updated
+      return null;
+    }
+
+    CiResource attachmentDetails = getPlatformComponentAttachment(assemblyName, platformName, componentName, attachmentName);
+    if (attachmentDetails != null) {
+      ResourceObject ro = new ResourceObject();
+
+      Long ciId = attachmentDetails.getCiId();
+      RequestSpecification request = createRequest();
+
+      //Add existing ciAttributes 
+      CiAttributes ciAttributes = attachmentDetails.getCiAttributes();
+      Map<String, String> attr = Maps.newHashMap();
+      if (ciAttributes != null && ciAttributes.getAdditionalProperties() != null && ciAttributes.getAdditionalProperties().size() > 0) {
+        for (Entry<String, Object> entry : ciAttributes.getAdditionalProperties().entrySet()) {
+          attr.put(entry.getKey(), String.valueOf(entry.getValue()));
+        }
+      }
+
+      //Add ciAttributes to be updated
+      if (attributes != null && attributes.size() > 0)
+        attr.putAll(attributes);
+
+      Map<String, String> ownerProps = Maps.newHashMap();
+      //Add existing attrProps to retain locking of attributes 
+      AttrProps attrProps = attachmentDetails.getAttrProps();
+      if (attrProps != null && attrProps.getAdditionalProperties() != null && attrProps.getAdditionalProperties().size() > 0 && attrProps.getAdditionalProperties().get("owner") != null) {
+        Map<String, String> ownersMap = (Map<String, String>) attrProps.getAdditionalProperties().get("owner");
+        for (Entry<String, String> entry : ownersMap.entrySet()) {
+          ownerProps.put(entry.getKey(), entry.getValue());
+        }
+      }
+
+      //Add updated attributes to attrProps to lock them
+      for (Entry<String, String> entry : attributes.entrySet()) {
+        ownerProps.put(entry.getKey(), "design");
+      }
+
+      ro.setOwnerProps(ownerProps);
+      ro.setAttributes(attr);
+      JSONObject jsonObject = JsonUtil.createJsonObject(ro, "cms_dj_ci");
+      Response response = request.body(jsonObject.toString()).put(designURI(assemblyName) + IConstants.PLATFORM_URI + platformName
+        + IConstants.COMPONENT_URI + componentName + IConstants.ATTACHMENTS_URI + ciId);
+      if (response != null) {
+        if (response.getStatusCode() == 200 || response.getStatusCode() == 302) {
+          return response.getBody().as(CiResource.class);
+        } else {
+          String msg = String.format("Failed to get update attachment %s due to %s", componentName, response.getStatusLine());
+          throw new OneOpsClientAPIException(msg);
+        }
+      }
+    }
+    String msg = String.format("Failed to get update attachment %s due to null response", componentName);
+    throw new OneOpsClientAPIException(msg);
+  }
+
+  /**
+   * Add attachment to a given assembly/design/platform/component
+   * 
+   * @param platformName
+   * @param componentName
+   * @param attributes
+   * 
+   * Sample request for new attachment attributes
+   *  attributes.put("content", "content");
+    attributes.put("source", "source");
+    attributes.put("path", "/tmp/my.sh");
+    attributes.put("exec_cmd", "exec_cmd");
+    attributes.put("run_on", "after-add,after-replace,after-update");
+    attributes.put("run_on_action", "[\"after-restart\"]");
+   * @return
+   * @throws OneOpsClientAPIException
+   */
+  public CiResource addNewAttachment(String assemblyName, String platformName, String componentName, String uniqueName, Map<String, String> attributes) throws OneOpsClientAPIException {
+    RequestSpecification request = createRequest();
+
+    Response newAttachmentResponse = request.get(designURI(assemblyName) + IConstants.PLATFORM_URI + platformName + IConstants.COMPONENT_URI + componentName + IConstants.ATTACHMENTS_URI + "new.json");
+    if (newAttachmentResponse != null) {
+      ResourceObject ro = new ResourceObject();
+      Map<String, String> properties = Maps.newHashMap();
+      properties.put("ciName", uniqueName);
+      properties.put("rfcAction", "add");
+
+      JsonPath attachmentDetails = newAttachmentResponse.getBody().jsonPath();
+      Map<String, String> attr = attachmentDetails.getMap("ciAttributes");
+      if (attr == null) {
+        attr = Maps.newHashMap();
+      }
+      if (attributes != null && attributes.size() > 0) {
+        attr.putAll(attributes);
+
+        Map<String, String> ownerProps = attachmentDetails.getMap("ciAttrProps.owner");
+        if (ownerProps == null) {
+          ownerProps = Maps.newHashMap();
+        }
+        for (Entry<String, String> entry : attributes.entrySet()) {
+          ownerProps.put(entry.getKey(), "design");
+        }
+        ro.setOwnerProps(ownerProps);
+      }
+      ro.setAttributes(attr);
+      ro.setProperties(properties);
+      JSONObject jsonObject = JsonUtil.createJsonObject(ro, "cms_dj_ci");
+      Response response =
+        request.body(jsonObject.toString()).post(designURI(assemblyName) + IConstants.PLATFORM_URI + platformName + IConstants.COMPONENT_URI + componentName + IConstants.ATTACHMENTS_URI);
+      if (response != null) {
+        if (response.getStatusCode() == 200 || response.getStatusCode() == 302) {
+          return response.getBody().as(CiResource.class);
+        } else {
+          String msg = String.format("Failed to get add attachment to %s due to %s", componentName, response.getStatusLine());
+          throw new OneOpsClientAPIException(msg);
+        }
+      }
+    }
+
+    String msg = String.format("Failed to get add attachment to %s due to null response", componentName);
+    throw new OneOpsClientAPIException(msg);
+  }
+
+  /**
+   * List local variables for a given assembly/design/platform
+   * 
+   * @param platformName
+   * @return
+   * @throws OneOpsClientAPIException
+   */
+  public List<CiResource> listPlatformVariables(String assemblyName, String platformName) throws OneOpsClientAPIException {
+    if (platformName == null || platformName.length() == 0) {
+      String msg = "Missing platform name to list platform variables";
+      throw new OneOpsClientAPIException(msg);
+    }
+    RequestSpecification request = createRequest();
+    Response response = request.get(designURI(assemblyName) + IConstants.PLATFORM_URI + platformName + IConstants.VARIABLES_URI);
+    if (response != null) {
+      if (response.getStatusCode() == 200 || response.getStatusCode() == 302) {
+        return JsonUtil.toObject(response.getBody().asString(), new TypeReference<List<CiResource>>() {});
+      } else {
+        String msg = String.format("Failed to get list of design platforms variables due to %s", response.getStatusLine());
+        throw new OneOpsClientAPIException(msg);
+      }
+    }
+    String msg = "Failed to get list of design platforms variables due to null response";
+    throw new OneOpsClientAPIException(msg);
+  }
+
+  /**
+   * Add platform variables for a given assembly/design
+   * 
+   * @param environmentName
+   * @param variables
+   * @return
+   * @throws OneOpsClientAPIException
+   */
+  public CiResource addPlatformVariable(String assemblyName, String platformName, String variableName, String variableValue, boolean isSecure) throws OneOpsClientAPIException {
+    if (platformName == null || platformName.length() == 0) {
+      String msg = "Missing platform name to add variables";
+      throw new OneOpsClientAPIException(msg);
+    }
+    if (variableName == null) {
+      String msg = "Missing variable name to be added";
+      throw new OneOpsClientAPIException(msg);
+    }
+
+    if (variableValue == null) {
+      String msg = "Missing variable value to be added";
+      throw new OneOpsClientAPIException(msg);
+    }
+
+    RequestSpecification request = createRequest();
+
+    Response variable = request.get(designURI(assemblyName) + IConstants.PLATFORM_URI + platformName + IConstants.VARIABLES_URI + variableName);
+    if (variable != null && variable.getBody() != null && variable.getBody().jsonPath().getString("ciId") != null) {
+      String msg = String.format("Global variables %s already exists", variableName);
+      throw new OneOpsClientAPIException(msg);
+    }
+    ResourceObject ro = new ResourceObject();
+    Response newVarResponse = request.get(designURI(assemblyName) + IConstants.PLATFORM_URI + platformName + IConstants.VARIABLES_URI + "new.json");
+    if (newVarResponse != null) {
+      JsonPath newVarJsonPath = newVarResponse.getBody().jsonPath();
+      if (newVarJsonPath != null) {
+        Map<String, String> attr = newVarJsonPath.getMap("ciAttributes");
+        Map<String, String> properties = Maps.newHashMap();
+        if (attr == null) {
+          attr = Maps.newHashMap();
+        }
+        if (isSecure) {
+          attr.put("secure", "true");
+          attr.put("encrypted_value", variableValue);
+        } else {
+          attr.put("secure", "false");
+          attr.put("value", variableValue);
+        }
+
+        properties.put("ciName", variableName);
+        ro.setProperties(properties);
+        ro.setAttributes(attr);
+      }
+    }
+
+    JSONObject jsonObject = JsonUtil.createJsonObject(ro, "cms_dj_ci");
+
+    Response response = request.body(jsonObject.toString()).post(designURI(assemblyName) + IConstants.PLATFORM_URI + platformName + IConstants.VARIABLES_URI);
+    if (response != null) {
+      if (response.getStatusCode() == 200 || response.getStatusCode() == 302) {
+        return response.getBody().as(CiResource.class);
+      } else {
+        String msg = String.format("Failed to add platform variable %s due to %s", variableName, response.getStatusLine());
+        throw new OneOpsClientAPIException(msg);
+      }
+    }
+
+    String msg = String.format("Failed to add new variables %s due to null response", variableName);
+    throw new OneOpsClientAPIException(msg);
+  }
+
+  /**
+   * Update platform local variables for a given assembly/design/platform
+   * 
+   * @param platformName
+   * @param variables
+   * @return
+   * @throws OneOpsClientAPIException
+   */
+  public Boolean updatePlatformVariable(String assemblyName, String platformName, String variableName, String variableValue, boolean isSecure) throws OneOpsClientAPIException {
+    if (platformName == null || platformName.length() == 0) {
+      String msg = "Missing platform name to update variables";
+      throw new OneOpsClientAPIException(msg);
+    }
+    if (variableName == null) {
+      String msg = "Missing variable name to be added";
+      throw new OneOpsClientAPIException(msg);
+    }
+
+    if (variableValue == null) {
+      String msg = "Missing variable value to be added";
+      throw new OneOpsClientAPIException(msg);
+    }
+
+    Boolean success = false;
+    RequestSpecification request = createRequest();
+
+    Response variable = request.get(designURI(assemblyName) + IConstants.PLATFORM_URI + platformName + IConstants.VARIABLES_URI + variableName);
+    if (variable == null || variable.getStatusCode() != 200 || variable.getBody() == null) {
+      String msg = String.format("Failed to find local variables %s for platform %s", variableName, platformName);
+      throw new OneOpsClientAPIException(msg);
+    }
+
+    JsonPath variableDetails = variable.getBody().jsonPath();
+    String ciId = variableDetails.getString("ciId");
+    Map<String, String> attr = variableDetails.getMap("ciAttributes");
+    if (attr == null) {
+      attr = new HashMap<String, String>();
+    }
+
+    if (isSecure) {
+      attr.put("secure", "true");
+      attr.put("encrypted_value", variableValue);
+    } else {
+      attr.put("secure", "false");
+      attr.put("value", variableValue);
+    }
+
+    ResourceObject ro = new ResourceObject();
+    ro.setAttributes(attr);
+
+    JSONObject jsonObject = JsonUtil.createJsonObject(ro, "cms_dj_ci");
+
+    Response response = request.body(jsonObject.toString()).put(designURI(assemblyName) + IConstants.PLATFORM_URI + platformName + IConstants.VARIABLES_URI + ciId);
+    if (response != null) {
+      if (response.getStatusCode() == 200 || response.getStatusCode() == 302) {
+        //return response.getBody().jsonPath();
+        success = true;
+      } else {
+        String msg = String.format("Failed to get update variables %s due to %s", variableName, response.getStatusLine());
+        throw new OneOpsClientAPIException(msg);
+      }
+    }
+
+    return success;
+  }
+
+  /**
+   * Update platform local variables for a given assembly/design/platform
+   * 
+   * @param platformName
+   * @param variables
+   * @return
+   * @throws OneOpsClientAPIException
+   */
+  public Boolean updateOrAddPlatformVariables(String assemblyName, String platformName, String variableName, String variableValue, boolean isSecure) throws OneOpsClientAPIException {
+    if (platformName == null || platformName.length() == 0) {
+      String msg = "Missing platform name to update variables";
+      throw new OneOpsClientAPIException(msg);
+    }
+    if (variableName == null) {
+      String msg = "Missing variable name to be added";
+      throw new OneOpsClientAPIException(msg);
+    }
+
+    if (variableValue == null) {
+      String msg = "Missing variable value to be added";
+      throw new OneOpsClientAPIException(msg);
+    }
+
+    RequestSpecification request = createRequest();
+
+    Response variable = request.get(designURI(assemblyName) + IConstants.PLATFORM_URI + platformName + IConstants.VARIABLES_URI + variableName);
+    if (variable == null || variable.getStatusCode() != 200 || variable.getBody() == null) {
+      return addPlatformVariable(assemblyName, platformName, variableName, variableValue, isSecure) == null ? false : true;
+    } else {
+      return updatePlatformVariable(assemblyName, platformName, variableName, variableValue, isSecure) == null ? false : true;
+    }
+  }
+
+  /**
+   * Deletes the given platform variable
+   * 
+   * @param platformName
+   * @param variableName
+   * @return
+   * @throws OneOpsClientAPIException
+   */
+
+  public CiResource deletePlatformVariable(String assemblyName, String platformName, String variableName) throws OneOpsClientAPIException {
+    if (platformName == null || platformName.length() == 0) {
+      String msg = "Missing platform name to delete variable";
+      throw new OneOpsClientAPIException(msg);
+    }
+    if (variableName == null || variableName.length() == 0) {
+      String msg = "Missing variable name to delete it";
+      throw new OneOpsClientAPIException(msg);
+    }
+
+    RequestSpecification request = createRequest();
+    Response response = request.delete(designURI(assemblyName) + IConstants.PLATFORM_URI + platformName + IConstants.VARIABLES_URI + variableName);
+    if (response != null) {
+      if (response.getStatusCode() == 200 || response.getStatusCode() == 302) {
+        return response.getBody().as(CiResource.class);
+      } else {
+        String msg = String.format("Failed to delete platform with name %s due to %s", platformName, response.getStatusLine());
+        throw new OneOpsClientAPIException(msg);
+      }
+    }
+    String msg = String.format("Failed to delete platform with name %s due to null response", platformName);
+    throw new OneOpsClientAPIException(msg);
+  }
+
+  /**
+   * List global variables for a given assembly/design
+   * 
+   * @return
+   * @throws OneOpsClientAPIException
+   */
+  public List<CiResource> listGlobalVariables(String assemblyName) throws OneOpsClientAPIException {
+    RequestSpecification request = createRequest();
+    Response response = request.get(designURI(assemblyName) + IConstants.VARIABLES_URI);
+    if (response != null) {
+      if (response.getStatusCode() == 200 || response.getStatusCode() == 302) {
+        return JsonUtil.toObject(response.getBody().asString(), new TypeReference<List<CiResource>>() {});
+      } else {
+        String msg = String.format("Failed to get list of design variables due to %s", response.getStatusLine());
+        throw new OneOpsClientAPIException(msg);
+      }
+    }
+    String msg = "Failed to get list of design variables due to null response";
+    throw new OneOpsClientAPIException(msg);
+  }
+
+  /**
+   * Add global variables for a given assembly/design
+   * 
+   * @param environmentName
+   * @param variables
+   * @return
+   * @throws OneOpsClientAPIException
+   */
+  public CiResource addGlobalVariable(String assemblyName, String variableName, String variableValue, boolean isSecure) throws OneOpsClientAPIException {
+    if (variableName == null) {
+      String msg = "Missing variable name to be added";
+      throw new OneOpsClientAPIException(msg);
+    }
+
+    if (variableValue == null) {
+      String msg = "Missing variable value to be added";
+      throw new OneOpsClientAPIException(msg);
+    }
+
+    RequestSpecification request = createRequest();
+
+    Response variable = request.get(designURI(assemblyName) + IConstants.VARIABLES_URI + variableName);
+    if (variable != null && variable.getBody() != null && variable.getBody().jsonPath().getString("ciId") != null) {
+      String msg = String.format("Global variables %s already exists", variableName);
+      throw new OneOpsClientAPIException(msg);
+    }
+    ResourceObject ro = new ResourceObject();
+    Response newVarResponse = request.get(designURI(assemblyName) + IConstants.VARIABLES_URI + "new.json");
+    if (newVarResponse != null) {
+      JsonPath newVarJsonPath = newVarResponse.getBody().jsonPath();
+      if (newVarJsonPath != null) {
+        Map<String, String> attr = newVarJsonPath.getMap("ciAttributes");
+        Map<String, String> properties = Maps.newHashMap();
+        if (attr == null) {
+          attr = Maps.newHashMap();
+        }
+        if (isSecure) {
+          attr.put("secure", "true");
+          attr.put("encrypted_value", variableValue);
+        } else {
+          attr.put("secure", "false");
+          attr.put("value", variableValue);
+        }
+
+        properties.put("ciName", variableName);
+        ro.setProperties(properties);
+        ro.setAttributes(attr);
+      }
+    }
+
+    JSONObject jsonObject = JsonUtil.createJsonObject(ro, "cms_dj_ci");
+
+    Response response = request.body(jsonObject.toString()).post(designURI(assemblyName) + IConstants.VARIABLES_URI);
+    if (response != null) {
+      if (response.getStatusCode() == 200 || response.getStatusCode() == 302) {
+        return response.getBody().as(CiResource.class);
+      } else {
+        String msg = String.format("Failed to get new global variable %s due to %s", variableName, response.getStatusLine());
+        throw new OneOpsClientAPIException(msg);
+      }
+    }
+
+    String msg = String.format("Failed to add new variables %s due to null response", variableName);
+    throw new OneOpsClientAPIException(msg);
+  }
+
+  /**
+   * Update global variables for a given assembly/design
+   * 
+   * @param environmentName
+   * @param variables
+   * @return
+   * @throws OneOpsClientAPIException
+   */
+  public Boolean updateGlobalVariable(String assemblyName, String variableName, String variableValue, boolean isSecure) throws OneOpsClientAPIException {
+    if (variableName == null) {
+      String msg = "Missing variable name to be added";
+      throw new OneOpsClientAPIException(msg);
+    }
+
+    if (variableValue == null) {
+      String msg = "Missing variable value to be added";
+      throw new OneOpsClientAPIException(msg);
+    }
+
+    Boolean success = false;
+    RequestSpecification request = createRequest();
+
+    Response variable = request.get(designURI(assemblyName) + IConstants.VARIABLES_URI + variableName);
+    if (variable == null || variable.getBody() == null) {
+      String msg = String.format("Failed to find global variables %s", variableName);
+      throw new OneOpsClientAPIException(msg);
+    }
+    JsonPath variableDetails = variable.getBody().jsonPath();
+    String ciId = variableDetails.getString("ciId");
+    Map<String, String> attr = variableDetails.getMap("ciAttributes");
+    if (attr == null) {
+      attr = new HashMap<String, String>();
+    }
+    if (isSecure) {
+      attr.put("secure", "true");
+      attr.put("encrypted_value", variableValue);
+    } else {
+      attr.put("secure", "false");
+      attr.put("value", variableValue);
+    }
+
+    ResourceObject ro = new ResourceObject();
+    ro.setAttributes(attr);
+
+    JSONObject jsonObject = JsonUtil.createJsonObject(ro, "cms_dj_ci");
+
+    Response response = request.body(jsonObject.toString()).put(designURI(assemblyName) + IConstants.VARIABLES_URI + ciId);
+    if (response != null) {
+      if (response.getStatusCode() == 200 || response.getStatusCode() == 302) {
+        success = true;
+      } else {
+        String msg = String.format("Failed to get update global variable %s due to %s", variableName, response.getStatusLine());
+        throw new OneOpsClientAPIException(msg);
+      }
+    }
+
+    return success;
+  }
+
+  /**
+   * Fetches specific platform details in Yaml format
+   * 
+   * @return
+   * @throws OneOpsClientAPIException
+   */
+  public JsonPath extractYaml(String assemblyName) throws OneOpsClientAPIException {
+    RequestSpecification request = createRequest();
+
+    Response response = request.get(designURI(assemblyName) + "/extract.yaml");
+    if (response != null) {
+      if (response.getStatusCode() == 200 || response.getStatusCode() == 302) {
+        return response.getBody().jsonPath();
+      } else {
+        String msg = String.format("Failed to extract yaml content due to %s", response.getStatusLine());
+        throw new OneOpsClientAPIException(msg);
+      }
+    }
+    String msg = "Failed to extract yaml content due to null response";
+    throw new OneOpsClientAPIException(msg);
+  }
+
+  /**
+   * Adds specific platform from Yaml/Json file input
+   * 
+   * @param platformName
+   * @return
+   * @throws OneOpsClientAPIException
+   */
+  public JsonPath loadFile(String assemblyName, String filecontent) throws OneOpsClientAPIException {
+    if (filecontent == null || filecontent.length() == 0) {
+      String msg = "Missing input file content";
+      throw new OneOpsClientAPIException(msg);
+    }
+
+    RequestSpecification request = createRequest();
+    request.header("Content-Type", "multipart/text");
+    JSONObject jo = new JSONObject();
+    jo.put("data", filecontent);
+
+    Response response = request.parameter("data", filecontent).put(designURI(assemblyName) + "/load");
+    if (response != null) {
+      if (response.getStatusCode() == 200 || response.getStatusCode() == 302) {
+        return response.getBody().jsonPath();
+      } else {
+        String msg = String.format("Failed to load yaml content due to %s", response.getStatusLine());
+        throw new OneOpsClientAPIException(msg);
+      }
+    }
+    String msg = "Failed to load yaml content due to null response";
+    throw new OneOpsClientAPIException(msg);
+  }
+
+  private String designURI(String assemblyName) {
+    return IConstants.ASSEMBLY_URI + assemblyName + IConstants.DESIGN_URI;
+  }
+
+  private String designReleaseURI(String assemblyName) {
+    return IConstants.ASSEMBLY_URI + assemblyName + IConstants.DESIGN_URI + IConstants.RELEASES_URI;
+  }
+
+  // Monitor
+
+  /**
+   * Fetches specific monitor details
+   * 
+   * @param monitorName
+   * @return
+   * @throws OneOpsClientAPIException
+   */
+  public CiResource getMonitor(String assemblyName, String platform, String component, String environmentName, String monitorName) throws OneOpsClientAPIException {
+    if (monitorName == null || monitorName.length() == 0) {
+      String msg = "Missing monitor name to fetch details";
+      throw new OneOpsClientAPIException(msg);
+    }
+
+    RequestSpecification request = createRequest();
+    Response response = request.get(transitionMonitorUri(assemblyName, platform, component, environmentName) + monitorName);
+    if (response != null) {
+      if (response.getStatusCode() == 200 || response.getStatusCode() == 302) {
+        return response.getBody().as(CiResource.class);
+      } else {
+        String msg = String.format("Failed to get environment with name %s due to %s", environmentName, response.getStatusLine());
+        throw new OneOpsClientAPIException(msg);
+      }
+    }
+    String msg = String.format("Failed to get environment with name %s due to null response", environmentName);
+    throw new OneOpsClientAPIException(msg);
+  }
+
+  /**
+   * Update monitor
+   * 
+   * @param monitorName
+   * @param cmdOptions
+   * @param duration
+   * @param sampleInterval
+   * @param thresholds
+   * @param heartbeat
+   * @param enable
+   * @return
+   * @throws OneOpsClientAPIException
+   */
+  public CiResource updateMonitor(String assemblyName, String platform, String component, String environmentName,
+    String monitorName, String cmdOptions, Integer duration, Integer sampleInterval, JSONObject thresholds, boolean heartbeat, boolean enable) throws OneOpsClientAPIException {
+    if (monitorName == null || monitorName.length() == 0) {
+      String msg = "Missing monitor name to fetch details";
+      throw new OneOpsClientAPIException(msg);
+    }
+
+    RequestSpecification request = createRequest();
+    Response response = request.get(transitionMonitorUri(assemblyName, platform, component, environmentName) + monitorName);
+
+    ResourceObject ro = new ResourceObject();
+    Map<String, String> attributes = new HashMap<String, String>();
+    JSONObject monitor = JsonUtil.createJsonObject(response.getBody().asString());
+    if (monitor != null && monitor.has("ciAttributes")) {
+      JSONObject attrs = monitor.getJSONObject("ciAttributes");
+      for (Object key : attrs.keySet()) {
+        //based on you key types
+        String keyStr = (String) key;
+        String keyvalue = String.valueOf(attrs.get(keyStr));
+
+        attributes.put(keyStr, keyvalue);
+
+        if (cmdOptions != null && attributes.containsKey("cmd_options")) {
+          attributes.put("cmd_options", String.valueOf(cmdOptions));
+        }
+
+        if (duration != null && attributes.containsKey("duration")) {
+          attributes.put("duration", String.valueOf(duration));
+        }
+
+        if (sampleInterval != null && attributes.containsKey("sample_interval")) {
+          attributes.put("sample_interval", String.valueOf(sampleInterval));
+        }
+
+        if (thresholds != null && attributes.containsKey("thresholds")) {
+          attributes.put("thresholds", thresholds.toString());
+        }
+
+      }
+      attributes.put("heartbeat", String.valueOf(heartbeat));
+      attributes.put("enable", String.valueOf(enable));
+    }
+    ro.setAttributes(attributes);
+    JSONObject jsonObject = JsonUtil.createJsonObject(ro, "cms_dj_ci");
+    response = request.body(jsonObject.toString()).put(transitionMonitorUri(assemblyName, platform, component, environmentName) + monitorName);
+    if (response != null) {
+      if (response.getStatusCode() == 200 || response.getStatusCode() == 302) {
+        return response.getBody().as(CiResource.class);
+      } else {
+        String msg = String.format("Failed to monitor definition for monitor %s due to %s", monitorName, response.getStatusLine());
+        throw new OneOpsClientAPIException(msg);
+      }
+    }
+
+    String msg = String.format("Failed to update monitor definition for %s due to null response", monitorName);
+    throw new OneOpsClientAPIException(msg);
+  }
+
+
+  public JSONObject getThresholdJson(String name, String state, String metric, String bucket, String stat, JSONObject trigger, JSONObject reset) {
+    JSONObject thresholdDef = new JSONObject();
+    thresholdDef.put("bucket", bucket);
+    thresholdDef.put("metric", metric);
+    thresholdDef.put("state", state);
+    thresholdDef.put("stat", stat);
+    thresholdDef.put("trigger", trigger);
+    thresholdDef.put("reset", reset);
+
+    JSONObject threshold = new JSONObject();
+    threshold.put(name, thresholdDef);
+
+    return threshold;
+  }
+
+  public JSONObject createThresholdCondition(String operator, int value, int duration, int numOfOccurances) {
+    JSONObject thresholdCondition = new JSONObject();
+    thresholdCondition.put("operator", operator);
+    thresholdCondition.put("value", value);
+    thresholdCondition.put("duration", duration);
+    thresholdCondition.put("numocc", numOfOccurances);
+
+    return thresholdCondition;
+  }
+
+  public JSONObject addMetrics(String metricName, String unit, String dstype, String display, String description) {
+    JSONObject metricinfo = new JSONObject();
+    metricinfo.put("unit", unit);
+    metricinfo.put("dstype", dstype);
+    metricinfo.put("display", display);
+    metricinfo.put("display_group", "");
+    metricinfo.put("description", description);
+    return metricinfo;
+  }
+
+  //list thresholds
+  //add threshold
+  //update threshold
+  //delete threshold  
+
+  private String transitionMonitorUri(String assemblyName, String platform, String component, String environmentName) {
+    return IConstants.ASSEMBLY_URI + assemblyName + IConstants.TRANSITION_URI + IConstants.ENVIRONMENT_URI + environmentName
+      + IConstants.PLATFORM_URI + platform
+      + IConstants.COMPONENT_URI + component + IConstants.MONITORS_URI;
+  }
+
+  // Operation
+
+  public CiResource updatePlatformAutoHealingStatus(String assemblyName, String environmentName, String platformName, String healingOption, boolean isEnabled) throws OneOpsClientAPIException {
+    if (environmentName == null || environmentName.length() == 0) {
+      String msg = String.format("Missing environment name to be updated");
+      throw new OneOpsClientAPIException(msg);
+    }
+
+    if (platformName == null || platformName.length() == 0) {
+      String msg = String.format("Missing platform name to be updated");
+      throw new OneOpsClientAPIException(msg);
+    }
+
+    if (healingOption == null || healingOption.length() == 0) {
+      String msg = String.format("No healing options available to be updated");
+      throw new OneOpsClientAPIException(msg);
+    }
+
+    RequestSpecification request = createRequest();
+
+    String enabled = "disable";
+    if (isEnabled) {
+      enabled = "enable";
+    }
+
+    Response response = request.body("").queryParam("status", enabled)
+      .put(operationURI(assemblyName, environmentName) + IConstants.PLATFORM_URI + platformName + "/" + healingOption);
+    if (response != null) {
+      if (response.getStatusCode() == 200 || response.getStatusCode() == 302) {
+        return response.getBody().as(CiResource.class);
+      } else {
+        String msg = String.format("Failed to update platforms due to %s", response.getStatusLine());
+        throw new OneOpsClientAPIException(msg);
+      }
+    }
+    String msg = String.format("Failed to update platforms due to null response");
+    throw new OneOpsClientAPIException(msg);
+  }
+
+  public CiResource updatePlatformAutoReplaceConfig(String assemblyName, String environmentName, String platformName, int repairCount, int repairTime) throws OneOpsClientAPIException {
+    if (environmentName == null || environmentName.length() == 0) {
+      String msg = String.format("Missing environment name to be updated");
+      throw new OneOpsClientAPIException(msg);
+    }
+
+    if (platformName == null || platformName.length() == 0) {
+      String msg = String.format("Missing platform name to be updated");
+      throw new OneOpsClientAPIException(msg);
+    }
+
+    RequestSpecification request = createRequest();
+    JSONObject jo = new JSONObject();
+    jo.put("replace_after_minutes", String.valueOf(repairTime));
+    jo.put("replace_after_repairs", String.valueOf(repairCount));
+
+    Response response = request.body(jo.toString())
+      .put(operationURI(assemblyName, environmentName) + IConstants.PLATFORM_URI + platformName + "/autoreplace");
+    if (response != null) {
+      if (response.getStatusCode() == 200 || response.getStatusCode() == 302) {
+        return response.getBody().as(CiResource.class);
+      } else {
+        String msg = String.format("Failed to update platforms due to %s", response.getStatusLine());
+        throw new OneOpsClientAPIException(msg);
+      }
+    }
+    String msg = String.format("Failed to update platforms due to null response");
+    throw new OneOpsClientAPIException(msg);
+  }
+
+  /**
+   * Lists all instances for a given assembly, environment, platform and component
+   * 
+   * @return
+   * @throws OneOpsClientAPIException
+   */
+  public List<CiResource> listInstances(String assemblyName, String environmentName, String platformName, String componentName) throws OneOpsClientAPIException {
+    if (platformName == null || platformName.length() == 0) {
+      String msg = "Missing platform name to fetch details";
+      throw new OneOpsClientAPIException(msg);
+    }
+    if (componentName == null || componentName.length() == 0) {
+      String msg = "Missing component name to fetch details";
+      throw new OneOpsClientAPIException(msg);
+    }
+
+    RequestSpecification request = createRequest();
+    Response response = request.queryParam("instances_state", "all").get(operationURI(assemblyName, environmentName)
+      + IConstants.PLATFORM_URI + platformName
+      + IConstants.COMPONENT_URI + componentName
+      + IConstants.INSTANCES_URI);
+    if (response != null) {
+      if (response.getStatusCode() == 200 || response.getStatusCode() == 302) {
+        return JsonUtil.toObject(response.getBody().asString(), new TypeReference<List<CiResource>>() {});
+      } else {
+        String msg = String.format("Failed to get instances due to %s", response.getStatusLine());
+        throw new OneOpsClientAPIException(msg);
+      }
+    }
+    String msg = "Failed to get instances due to null response";
+    throw new OneOpsClientAPIException(msg);
+  }
+
+
+  /**
+   * Mark all instances for replacement for a given platform and component
+   * 
+   * @return
+   * @throws OneOpsClientAPIException
+   */
+  public Boolean markInstancesForReplacement(String assemblyName, String environmentName, String platformName, String componentName) throws OneOpsClientAPIException {
+    List<CiResource> instances = listInstances(assemblyName, environmentName, platformName, componentName);
+    List<Long> instanceIds = Lists.newArrayList();
+    for (CiResource ciResource : instances) {
+      instanceIds.add(ciResource.getCiId());
+    }
+    return markInstancesForReplacement(assemblyName, platformName, componentName, instanceIds);
+  }
+
+  /**
+   * Mark an instance for replacement for a given platform and component
+   * 
+   * @return
+   * @throws OneOpsClientAPIException
+   */
+  public Boolean markInstanceForReplacement(String assemblyName, String platformName, String componentName, Long instanceId) throws OneOpsClientAPIException {
+    List<Long> instanceIds = Lists.newArrayList();
+    instanceIds.add(instanceId);
+    return markInstancesForReplacement(assemblyName, platformName, componentName, instanceIds);
+  }
+
+  /**
+   * Mark an instance for replacement for a given platform and component
+   * 
+   * @return
+   * @throws OneOpsClientAPIException
+   */
+  Boolean markInstancesForReplacement(String assemblyName, String platformName, String componentName, List<Long> instanceIds) throws OneOpsClientAPIException {
+    RequestSpecification request = createRequest();
+    JSONObject jo = new JSONObject();
+    jo.put("ids", instanceIds);
+    jo.put("state", "replace");
+    String uri = IConstants.ASSEMBLY_URI + assemblyName + IConstants.OPERATION_URI + IConstants.INSTANCES_URI + "state";
+
+    Response response = request.body(jo.toString()).put(uri);
+    if (response != null) {
+      if (response.getStatusCode() == 200 || response.getStatusCode() == 302) {
+        return response.getBody().as(Boolean.class);
+      } else {
+        String msg = String.format("Failed to set replace marker on instance(s) due to %s", response.getStatusLine());
+        throw new OneOpsClientAPIException(msg);
+      }
+    }
+    String msg = "Failed to set replace marker on instance(s) due to null response";
+    throw new OneOpsClientAPIException(msg);
+  }
+
+  public JsonPath getLogData(String procedureId, List<String> actionIds) throws OneOpsClientAPIException {
+    RequestSpecification request = createRequest();
+    String uri = IConstants.OPERATION_URI + IConstants.PROCEDURES_URI + "log_data";
+    request.queryParam("procedure_id", procedureId);
+
+    if (actionIds != null) {
+      for (String actionId : actionIds) {
+        request.queryParam("action_ids", actionId);
+      }
+    }
+
+    Response response = request.get(uri);
+    if (response != null) {
+      if (response.getStatusCode() == 200 || response.getStatusCode() == 302) {
+        return response.getBody().jsonPath();
+      } else {
+        String msg = String.format("Failed to set replace marker on instance(s) due to %s", response.getStatusLine());
+        throw new OneOpsClientAPIException(msg);
+      }
+    }
+    String msg = "Failed to set replace marker on instance(s) due to null response";
+    throw new OneOpsClientAPIException(msg);
+  }
+
+  /**
+   * Lists all procedures for a given platform 
+   * 
+   * @return
+   * @throws OneOpsClientAPIException
+   */
+  public List<CiResource> listProcedures(String assemblyName, String environmentName, String platformName) throws OneOpsClientAPIException {
+    if (platformName == null || platformName.length() == 0) {
+      String msg = "Missing platform name to fetch details";
+      throw new OneOpsClientAPIException(msg);
+    }
+    RequestSpecification request = createRequest();
+    Response response = request.get(operationURI(assemblyName, environmentName)
+      + IConstants.PLATFORM_URI + platformName
+      + IConstants.PROCEDURES_URI);
+    if (response != null) {
+      if (response.getStatusCode() == 200 || response.getStatusCode() == 302) {
+        return JsonUtil.toObject(response.getBody().asString(), new TypeReference<List<CiResource>>() {});
+      } else {
+        String msg = String.format("Failed to get procedures due to %s", response.getStatusLine());
+        throw new OneOpsClientAPIException(msg);
+      }
+    }
+    String msg = "Failed to get procedures due to null response";
+    throw new OneOpsClientAPIException(msg);
+  }
+
+
+  /**
+   * Get procedure Id for a given platform, procedure name 
+   * 
+   * @return
+   * @throws OneOpsClientAPIException
+   */
+  public Long getProcedureId(String assemblyName, String environmentName, String platformName, String procedureName) throws OneOpsClientAPIException {
+    if (platformName == null || platformName.length() == 0) {
+      String msg = "Missing platform name to fetch details";
+      throw new OneOpsClientAPIException(msg);
+    }
+    if (procedureName == null || procedureName.length() == 0) {
+      String msg = "Missing procedure name to fetch details";
+      throw new OneOpsClientAPIException(msg);
+    }
+
+    List<CiResource> procs = listProcedures(assemblyName, environmentName, platformName);
+    if (procs != null) {
+      for (CiResource procedure : procs) {
+        if (procedureName.equals(procedure.getCiName())) {
+          return procedure.getCiId();
+        }
+      }
+    }
+
+    String msg = String.format("Failed to get procedure with the given name %s ", procedureName);
+    throw new OneOpsClientAPIException(msg);
+  }
+
+  /**
+   * Lists all actions for a given platform, component
+   * 
+   * @return
+   * @throws OneOpsClientAPIException
+   */
+  public JsonPath listActions(String assemblyName, String environmentName, String platformName, String componentName) throws OneOpsClientAPIException {
+    if (platformName == null || platformName.length() == 0) {
+      String msg = "Missing platform name to fetch details";
+      throw new OneOpsClientAPIException(msg);
+    }
+    if (componentName == null || componentName.length() == 0) {
+      String msg = "Missing component name to fetch details";
+      throw new OneOpsClientAPIException(msg);
+    }
+
+    RequestSpecification request = createRequest();
+    Response response = request.get(operationURI(assemblyName, environmentName)
+      + IConstants.PLATFORM_URI + platformName
+      + IConstants.COMPONENT_URI + componentName
+      + IConstants.ACTIONS_URI);
+    if (response != null) {
+      if (response.getStatusCode() == 200 || response.getStatusCode() == 302) {
+        return response.getBody().jsonPath();
+      } else {
+        String msg = String.format("Failed to get actions due to %s", response.getStatusLine());
+        throw new OneOpsClientAPIException(msg);
+      }
+    }
+    String msg = "Failed to get actions due to null response";
+    throw new OneOpsClientAPIException(msg);
+  }
+
+
+  /**
+   * Execute procedure for a given platform
+   * 
+   * @return
+   * @throws OneOpsClientAPIException
+   */
+  public Procedure executeProcedure(String assemblyName, String environmentName, String platformName, String procedureName, String arglist) throws OneOpsClientAPIException {
+    if (platformName == null || platformName.length() == 0) {
+      String msg = "Missing platform name to fetch details";
+      throw new OneOpsClientAPIException(msg);
+    }
+    if (procedureName == null || procedureName.length() == 0) {
+      String msg = "Missing procedure name to fetch details";
+      throw new OneOpsClientAPIException(msg);
+    }
+
+    RequestSpecification request = createRequest();
+    ResourceObject ro = new ResourceObject();
+    Map<String, String> properties = new HashMap<String, String>();
+
+    CiResource platform = getPlatform(environmentName, platformName);
+    Long platformId = platform.getCiId();
+    properties.put("procedureState", "active");
+    properties.put("arglist", arglist);
+    properties.put("definition", null);
+    properties.put("ciId", "" + platformId);
+    properties.put("procedureCiId", "" + getProcedureId(assemblyName, environmentName, platformName, procedureName));
+    ro.setProperties(properties);
+
+    JSONObject jsonObject = JsonUtil.createJsonObject(ro, "cms_procedure");
+    Response response = request.body(jsonObject.toString()).post(IConstants.OPERATION_URI + IConstants.PROCEDURES_URI);
+    if (response != null) {
+      if (response.getStatusCode() == 200 || response.getStatusCode() == 302) {
+        return response.getBody().as(Procedure.class);
+      } else {
+        String msg = String.format("Failed to execute procedures due to %s", response.getStatusLine());
+        throw new OneOpsClientAPIException(msg);
+      }
+    }
+    String msg = "Failed to execute procedures due to null response";
+    throw new OneOpsClientAPIException(msg);
+  }
+
+  /**
+   * Get procedure status for a given Id 
+   * 
+   * @return
+   * @throws OneOpsClientAPIException
+   */
+  public Procedure getProcedureStatus(Long procedureId) throws OneOpsClientAPIException {
+    if (procedureId == null) {
+      String msg = "Missing procedure Id to fetch details";
+      throw new OneOpsClientAPIException(msg);
+    }
+
+    RequestSpecification request = createRequest();
+    Response response = request.get(IConstants.OPERATION_URI + IConstants.PROCEDURES_URI + procedureId);
+    if (response != null) {
+      if (response.getStatusCode() == 200 || response.getStatusCode() == 302) {
+        return response.getBody().as(Procedure.class);
+      } else {
+        String msg = String.format("Failed to get procedure status due to %s", response.getStatusLine());
+        throw new OneOpsClientAPIException(msg);
+      }
+    }
+
+    String msg = String.format("Failed to get procedure status with the given Id " + procedureId);
+    throw new OneOpsClientAPIException(msg);
+  }
+
+  /**
+   * Get procedure status for a given Id 
+   * 
+   * @return
+   * @throws OneOpsClientAPIException
+   */
+  public Procedure cancelProcedure(Long procedureId) throws OneOpsClientAPIException {
+    if (procedureId == null) {
+      String msg = "Missing procedure Id to fetch details";
+      throw new OneOpsClientAPIException(msg);
+    }
+
+    RequestSpecification request = createRequest();
+    ResourceObject ro = new ResourceObject();
+    Map<String, String> properties = new HashMap<String, String>();
+
+    properties.put("procedureState", "canceled");
+    properties.put("definition", null);
+    properties.put("actions", null);
+    properties.put("procedureCiId", null);
+    properties.put("procedureId", null);
+    ro.setProperties(properties);
+
+    JSONObject jsonObject = JsonUtil.createJsonObject(ro, "cms_procedure");
+    Response response = request.body(jsonObject.toString()).put(IConstants.OPERATION_URI + IConstants.PROCEDURES_URI + procedureId);
+
+    if (response != null) {
+      if (response.getStatusCode() == 200 || response.getStatusCode() == 302) {
+        return response.getBody().as(Procedure.class);
+      } else {
+        String msg = String.format("Failed to cancel procedure due to %s", response.getStatusLine());
+        throw new OneOpsClientAPIException(msg);
+      }
+    }
+
+    String msg = String.format("Failed to cancel procedure with the given Id %s due to null response", procedureId);
+    throw new OneOpsClientAPIException(msg);
+  }
+
+  /**
+   * Execute procedure for a given platform
+   * 
+   * @return
+   * @throws OneOpsClientAPIException
+   */
+  public Procedure executeAction(String assemblyName, String environmentName, String platformName, String componentName, String actionName, List<Long> instanceList, String arglist, int rollingPercent)
+    throws OneOpsClientAPIException {
+    if (platformName == null || platformName.length() == 0) {
+      String msg = "Missing platform name to fetch details";
+      throw new OneOpsClientAPIException(msg);
+    }
+    if (componentName == null || componentName.length() == 0) {
+      String msg = "Missing component name to fetch details";
+      throw new OneOpsClientAPIException(msg);
+    }
+    if (actionName == null || actionName.length() == 0) {
+      String msg = "Missing action name to fetch details";
+      throw new OneOpsClientAPIException(msg);
+    }
+    if (instanceList == null || instanceList.size() == 0) {
+      String msg = "Missing instances list to fetch details";
+      throw new OneOpsClientAPIException(msg);
+    }
+
+    RequestSpecification request = createRequest();
+    ResourceObject ro = new ResourceObject();
+    Map<String, String> properties = new HashMap<String, String>();
+
+    CiResource component = getPlatformComponent(environmentName, platformName, componentName);
+    Long componentId = component.getCiId();
+    properties.put("procedureState", "active");
+    properties.put("arglist", arglist);
+
+    properties.put("ciId", "" + componentId);
+    properties.put("force", "true");
+    properties.put("procedureCiId", "0");
+
+    Map<String, Object> flow = Maps.newHashMap();
+    flow.put("targetIds", instanceList);
+    flow.put("relationName", "base.RealizedAs");
+    flow.put("direction", "from");
+
+    Map<String, Object> action = Maps.newHashMap();
+    action.put("isInheritable", null);
+    action.put("actionName", "base.RealizedAs");
+    action.put("inherited", null);
+    action.put("isCritical", "true");
+    action.put("stepNumber", "1");
+    action.put("extraInfo", null);
+    action.put("actionName", actionName);
+
+    List<Map<String, Object>> actions = Lists.newArrayList();
+    actions.add(action);
+    flow.put("actions", actions);
+
+    Map<String, Object> definition = new HashMap<String, Object>();
+    List<Map<String, Object>> flows = Lists.newArrayList();
+    flows.add(flow);
+    definition.put("flow", flows);
+    definition.put("name", actionName);
+
+    properties.put("definition", definition.toString());
+    ro.setProperties(properties);
+
+    JSONObject jsonObject = JsonUtil.createJsonObject(ro, "cms_procedure");
+    Response response = request.body(jsonObject.toString()).post(IConstants.OPERATION_URI + IConstants.PROCEDURES_URI);
+    if (response != null) {
+      if (response.getStatusCode() == 200 || response.getStatusCode() == 302) {
+        return response.getBody().as(Procedure.class);
+      } else {
+        String msg = String.format("Failed to execute procedures due to %s", response.getStatusLine());
+        throw new OneOpsClientAPIException(msg);
+      }
+    }
+    String msg = "Failed to execute procedures due to null response";
+    throw new OneOpsClientAPIException(msg);
+  }
+
+  private String operationURI(String assemblyName, String environmentName) {
+    return IConstants.ASSEMBLY_URI + assemblyName + IConstants.OPERATION_URI + IConstants.ENVIRONMENT_URI + environmentName;
+  }
+
+  // Transition
+
+  /**
+   * Fetches specific environment details
+   * 
+   * @param environmentName
+   * @return
+   * @throws OneOpsClientAPIException
+   */
+  public CiResource getEnvironment(String assemblyName, String environmentName) throws OneOpsClientAPIException {
+    if (environmentName == null || environmentName.length() == 0) {
+      String msg = "Missing environment name to fetch details";
+      throw new OneOpsClientAPIException(msg);
+    }
+
+    RequestSpecification request = createRequest();
+    Response response = request.get(transitionEnvUri(assemblyName) + environmentName);
+    if (response != null) {
+      if (response.getStatusCode() == 200 || response.getStatusCode() == 302) {
+        return response.getBody().as(CiResource.class);
+      } else {
+        String msg = String.format("Failed to get environment with name %s due to %s", environmentName, response.getStatusLine());
+        throw new OneOpsClientAPIException(msg);
+      }
+    }
+    String msg = String.format("Failed to get environment with name %s due to null response", environmentName);
+    throw new OneOpsClientAPIException(msg);
+  }
+
+
+  /**
+   * Lists all environments for a given assembly
+   * @return
+   * @throws OneOpsClientAPIException
+   */
+  public List<CiResource> listEnvironments(String assemblyName) throws OneOpsClientAPIException {
+
+    RequestSpecification request = createRequest();
+    Response response = request.get(transitionEnvUri(assemblyName));
+    if (response != null) {
+      if (response.getStatusCode() == 200 || response.getStatusCode() == 302) {
+        return JsonUtil.toObject(response.getBody().asString(), new TypeReference<List<CiResource>>() {});
+      } else {
+        String msg = String.format("Failed to list environments due to %s", response.getStatusLine());
+        throw new OneOpsClientAPIException(msg);
+      }
+    }
+    String msg = "Failed to list environments due to null response";
+    throw new OneOpsClientAPIException(msg);
+  }
+
+  /**
+   * Creates environment within the given assembly
+   * 
+   * @param environmentName {mandatory}
+   * @param envprofile if exists
+   * @param availability {mandatory}
+   * @param platformAvailability
+   * @param cloudMap {mandatory}
+   * @param debugFlag {mandatory}
+   * @param gdnsFlag {mandatory}
+   * @param description
+   * @return
+   * @throws OneOpsClientAPIException
+   */
+  public CiResource createEnvironment(String assemblyName, String environmentName, String envprofile, Map<String, String> attributes,
+    Map<String, String> platformAvailability, Map<String, Map<String, String>> cloudMap, String description) throws OneOpsClientAPIException {
+
+    ResourceObject ro = new ResourceObject();
+    Map<String, String> properties = new HashMap<String, String>();
+
+    if (environmentName != null && environmentName.length() > 0) {
+      properties.put("ciName", environmentName);
+    } else {
+      String msg = "Missing environment name to create environment";
+      throw new OneOpsClientAPIException(msg);
+    }
+    if (attributes == null) {
+      String msg = "Missing availability in attributes map to create environment";
+      throw new OneOpsClientAPIException(msg);
+    }
+
+    properties.put("nsPath", instance.getOrgname() + "/" + assemblyName);
+
+    String availability = null;
+    if (attributes.containsKey("availability")) {
+      availability = attributes.get("availability");
+    } else {
+      String msg = "Missing availability in attributes map to create environment";
+      throw new OneOpsClientAPIException(msg);
+    }
+
+    if (attributes.containsKey("global_dns")) {
+      attributes.put("global_dns", String.valueOf(attributes.get("global_dns")));
+    }
+
+    ro.setProperties(properties);
+    attributes.put("profile", envprofile);
+    attributes.put("description", description);
+    String subdomain = environmentName + "." + assemblyName + "." + instance.getOrgname();
+    attributes.put("subdomain", subdomain);
+    ro.setAttributes(attributes);
+
+    RequestSpecification request = createRequest();
+    JSONObject jsonObject = JsonUtil.createJsonObject(ro, "cms_ci");
+    if (platformAvailability == null || platformAvailability.size() == 0) {
+      List<CiResource> platforms = listPlatforms(assemblyName);
+      if (platforms != null) {
+        platformAvailability = new HashMap<String, String>();
+        for (CiResource platform : platforms) {
+          platformAvailability.put(platform.getCiId() + "", availability);
+        }
+      }
+    }
+    jsonObject.put("platform_availability", platformAvailability);
+
+    if (cloudMap == null || cloudMap.size() == 0) {
+      String msg = "Missing clouds map to create environment";
+      throw new OneOpsClientAPIException(msg);
+    }
+    jsonObject.put("clouds", cloudMap);
+
+    Response response = request.body(jsonObject.toString()).post(transitionEnvUri(assemblyName));
+
+    if (response != null) {
+      if (response.getStatusCode() == 200 || response.getStatusCode() == 302) {
+        return response.getBody().as(CiResource.class);
+      } else {
+        String msg = String.format("Failed to create environment with name %s due to %s", environmentName, response.getStatusLine());
+        throw new OneOpsClientAPIException(msg);
+      }
+    }
+    String msg = String.format("Failed to create environment with name %s due to null response", environmentName);
+    throw new OneOpsClientAPIException(msg);
+  }
+
+
+  /**
+   * Commits environment open releases
+   * 
+   * @param environmentName {mandatory}
+   * @param excludePlatforms
+   * @return
+   * @throws OneOpsClientAPIException
+   */
+  public Release commitEnvironment(String assemblyName, String environmentName, List<Long> excludePlatforms, String comment) throws OneOpsClientAPIException {
+
+    RequestSpecification request = createRequest();
+    JSONObject jo = new JSONObject();
+    if (excludePlatforms != null && excludePlatforms.size() > 0) {
+      StringBuilder sb = new StringBuilder();
+      for (int i = 0; i < excludePlatforms.size(); i++) {
+        sb.append(excludePlatforms.get(i));
+        if (i < (excludePlatforms.size() - 1)) {
+          sb.append(",");
+        }
+      }
+      jo.put("exclude_platforms", sb.toString());
+    }
+    if (comment != null)
+      jo.put("desc", comment);
+    Response response = request.body(jo.toString()).post(transitionEnvUri(assemblyName) + environmentName + "/commit");
+    if (response != null) {
+      if (response.getStatusCode() == 200 || response.getStatusCode() == 302) {
+
+        response = request.get(transitionEnvUri(assemblyName) + environmentName);
+        String envState = response.getBody().jsonPath().get("ciState");
+        //wait for deployment plan to generate
+        do {
+          Uninterruptibles.sleepUninterruptibly(5, TimeUnit.SECONDS);
+          response = request.get(transitionEnvUri(assemblyName) + environmentName);
+          if (response == null) {
+            String msg = String.format("Failed to commit environment due to null response");
+            throw new OneOpsClientAPIException(msg);
+          }
+          envState = response.getBody().jsonPath().get("ciState");
+        } while (response != null && "locked".equalsIgnoreCase(envState));
+
+        String comments = response.getBody().jsonPath().getString("comments");
+        if (comments != null && comments.startsWith("ERROR:")) {
+          String msg = String.format("Failed to commit environment due to %s", comments);
+          throw new OneOpsClientAPIException(msg);
+        }
+
+        return response.getBody().as(Release.class);
+
+      } else {
+        String msg = String.format("Failed to commit environment due to %s", response.getStatusLine());
+        throw new OneOpsClientAPIException(msg);
+      }
+    }
+    String msg = "Failed to commit environment due to null response";
+    throw new OneOpsClientAPIException(msg);
+  }
+
+  /**
+   * Deploy an already generated deployment plan
+   * 
+   * @param environmentName
+   * @return
+   * @throws OneOpsClientAPIException
+   */
+  public Deployment deploy(String assemblyName, String environmentName, String comments) throws OneOpsClientAPIException {
+
+    RequestSpecification request = createRequest();
+
+    Release bomRelease = getBomRelease(assemblyName, environmentName);
+    Long releaseId = bomRelease.getReleaseId();
+    String nsPath = bomRelease.getNsPath();
+    if (releaseId != null && nsPath != null) {
+      Map<String, String> properties = new HashMap<String, String>();
+      properties.put("nsPath", nsPath);
+      properties.put("releaseId", releaseId + "");
+      if (comments != null) {
+        properties.put("comments", comments);
+      }
+      ResourceObject ro = new ResourceObject();
+      ro.setProperties(properties);
+      JSONObject jsonObject = JsonUtil.createJsonObject(ro, "cms_deployment");
+      Response response = request.body(jsonObject.toString()).post(transitionEnvUri(assemblyName) + environmentName + "/deployments/");
+      if (response == null) {
+        String msg = String.format("Failed to start deployment for environment %s due to null response", environmentName);
+        throw new OneOpsClientAPIException(msg);
+      }
+      if (response.getStatusCode() == 200 || response.getStatusCode() == 302) {
+        return response.getBody().as(Deployment.class);
+      } else {
+        String msg = String.format("Failed to start deployment for environment %s due to null response", environmentName);
+        throw new OneOpsClientAPIException(msg);
+      }
+    } else {
+      String msg = String.format("Failed to find release id to be deployed");
+      throw new OneOpsClientAPIException(msg);
+    }
+
+
+  }
+
+
+  /**
+   * Fetches deployment status for the given assembly/environment
+   * 
+   * @param environmentName
+   * @param deploymentId
+   * @return
+   * @throws OneOpsClientAPIException
+   */
+  public Deployment getDeploymentStatus(String assemblyName, String environmentName, Long deploymentId) throws OneOpsClientAPIException {
+    if (environmentName == null || environmentName.length() == 0) {
+      String msg = "Missing environment name to fetch details";
+      throw new OneOpsClientAPIException(msg);
+    }
+    if (deploymentId == null) {
+      String msg = "Missing deployment to fetch details";
+      throw new OneOpsClientAPIException(msg);
+    }
+
+    RequestSpecification request = createRequest();
+    Response response = request.get(transitionEnvUri(assemblyName) + environmentName + IConstants.DEPLOYMENTS_URI + deploymentId + "/status");
+    if (response != null) {
+      if (response.getStatusCode() == 200 || response.getStatusCode() == 302) {
+        return response.getBody().as(Deployment.class);
+      } else {
+        String msg = String.format("Failed to get deployment status for environment %s with deployment Id %s due to %s", environmentName, deploymentId, response.getStatusLine());
+        throw new OneOpsClientAPIException(msg);
+      }
+    }
+    String msg = String.format("Failed to get deployment status for environment %s with deployment Id %s due to null response", environmentName, deploymentId);
+    throw new OneOpsClientAPIException(msg);
+  }
+
+  /**
+   * Fetches latest deployment for the given assembly/environment
+   * 
+   * @param environmentName
+   * @return
+   * @throws OneOpsClientAPIException
+   */
+  public Deployment getLatestDeployment(String assemblyName, String environmentName) throws OneOpsClientAPIException {
+    if (environmentName == null || environmentName.length() == 0) {
+      String msg = "Missing environment name to fetch details";
+      throw new OneOpsClientAPIException(msg);
+    }
+
+    RequestSpecification request = createRequest();
+    Response response = request.get(transitionEnvUri(assemblyName) + environmentName + IConstants.DEPLOYMENTS_URI + "latest");
+    if (response != null) {
+      if (response.getStatusCode() == 200 || response.getStatusCode() == 302) {
+        return response.getBody().as(Deployment.class);
+      } else {
+        String msg = String.format("Failed to get latest deployment for environment %s due to %s", environmentName, response.getStatusLine());
+        throw new OneOpsClientAPIException(msg);
+      }
+    }
+    String msg = String.format("Failed to get latest deployment for environment %s due to null response", environmentName);
+    throw new OneOpsClientAPIException(msg);
+  }
+
+
+  /**
+   * Discard already generated deployment plan
+   * 
+   * @param environmentName
+   * @return
+   * @throws OneOpsClientAPIException
+   */
+  public Release discardDeploymentPlan(String assemblyName, String environmentName) throws OneOpsClientAPIException {
+    if (environmentName == null || environmentName.length() == 0) {
+      String msg = "Missing environment name to fetch details";
+      throw new OneOpsClientAPIException(msg);
+    }
+
+    RequestSpecification request = createRequest();
+
+    Release bomRelease = getBomRelease(assemblyName, environmentName);
+    if (bomRelease != null) {
+      long releaseId = bomRelease.getReleaseId();
+      Response response = request.body("").post(transitionEnvUri(assemblyName) + environmentName + IConstants.RELEASES_URI + releaseId + "/discard");
+      if (response != null) {
+        if (response.getStatusCode() == 200 || response.getStatusCode() == 302) {
+          return response.getBody().as(Release.class);
+        } else {
+          String msg = String.format("Failed to discard deployment plan for environment %s due to %s", environmentName, response.getStatusLine());
+          throw new OneOpsClientAPIException(msg);
+        }
+      }
+    } else {
+      String msg = String.format("Failed to discard deployment plan for environment %s due to no open bom", environmentName);
+      throw new OneOpsClientAPIException(msg);
+    }
+
+    String msg = String.format("Failed to discard deployment plan for environment %s due to null response", environmentName);
+    throw new OneOpsClientAPIException(msg);
+  }
+
+  /**
+   * Discard uncommitted changes for the given {environmentName}
+   * 
+   * @param environmentName
+   * @return
+   * @throws OneOpsClientAPIException
+   */
+  public Release discardOpenRelease(String assemblyName, String environmentName) throws OneOpsClientAPIException {
+    if (environmentName == null || environmentName.length() == 0) {
+      String msg = "Missing environment name to fetch details";
+      throw new OneOpsClientAPIException(msg);
+    }
+
+    RequestSpecification request = createRequest();
+    Response response = request.body("").post(transitionEnvUri(assemblyName) + environmentName + "/discard");
+    if (response != null) {
+      if (response.getStatusCode() == 200 || response.getStatusCode() == 302) {
+        return response.getBody().as(Release.class);
+      } else {
+        String msg = String.format("Failed to discard changes for environment %s due to %s", environmentName, response.getStatusLine());
+        throw new OneOpsClientAPIException(msg);
+      }
+    }
+
+    String msg = String.format("Failed to discard changes for environment %s due to null response", environmentName);
+    throw new OneOpsClientAPIException(msg);
+  }
+
+  /**
+   * Disable all platforms for the given assembly/environment
+   * 
+   * @param environmentName
+   * @return
+   * @throws OneOpsClientAPIException
+   */
+  public CiResource disableAllPlatforms(String assemblyName, String environmentName) throws OneOpsClientAPIException {
+    if (environmentName == null || environmentName.length() == 0) {
+      String msg = "Missing environment name to disable all platforms";
+      throw new OneOpsClientAPIException(msg);
+    }
+
+    List<CiResource> ps = listPlatforms(environmentName);
+    List<Long> platformIds = Lists.newArrayList();
+    for (CiResource ciResource : ps) {
+      platformIds.add(ciResource.getCiId());
+    }
+
+    RequestSpecification request = createRequest();
+    Response response = request.queryParam("platformCiIds[]", platformIds).put(transitionEnvUri(assemblyName) + environmentName + "/disable");
+    if (response != null) {
+      if (response.getStatusCode() == 200 || response.getStatusCode() == 302) {
+        return response.getBody().as(CiResource.class);
+      } else {
+        String msg = String.format("Failed to disable platforms for environment %s due to %s", environmentName, response.getStatusLine());
+        throw new OneOpsClientAPIException(msg);
+      }
+    }
+    String msg = String.format("Failed to disable platforms for environment %s due to null response", environmentName);
+    throw new OneOpsClientAPIException(msg);
+  }
+
+  /**
+   * Fetches latest release for the given assembly/environment
+   * 
+   * @param environmentName
+   * @return
+   * @throws OneOpsClientAPIException
+   */
+  public Release getLatestRelease(String assemblyName, String environmentName) throws OneOpsClientAPIException {
+    if (environmentName == null || environmentName.length() == 0) {
+      String msg = "Missing environment name to fetch details";
+      throw new OneOpsClientAPIException(msg);
+    }
+
+    RequestSpecification request = createRequest();
+    Response response = request.get(transitionEnvUri(assemblyName) + environmentName + IConstants.RELEASES_URI + "latest");
+    if (response != null) {
+      if (response.getStatusCode() == 200 || response.getStatusCode() == 302) {
+        return response.getBody().as(Release.class);
+      } else {
+        String msg = String.format("Failed to get latest releases for environment %s due to %s", environmentName, response.getStatusLine());
+        throw new OneOpsClientAPIException(msg);
+      }
+    }
+    String msg = String.format("Failed to get latest releases for environment %s due to null response", environmentName);
+    throw new OneOpsClientAPIException(msg);
+  }
+
+
+  /**
+   * Fetches bom release for the given assembly/environment
+   * 
+   * @param environmentName
+   * @return
+   * @throws OneOpsClientAPIException
+   */
+  public Release getBomRelease(String assemblyName, String environmentName) throws OneOpsClientAPIException {
+    if (environmentName == null || environmentName.length() == 0) {
+      String msg = "Missing environment name to fetch details";
+      throw new OneOpsClientAPIException(msg);
+    }
+
+    RequestSpecification request = createRequest();
+    Response response = request.get(transitionEnvUri(assemblyName) + environmentName + IConstants.RELEASES_URI + "bom");
+    if (response != null) {
+      if (response.getStatusCode() == 200 || response.getStatusCode() == 302) {
+        return response.getBody().as(Release.class);
+      } else {
+        String msg = String.format("No bom releases found for environment %s ", environmentName);
+        System.out.println(msg);
+        return null;
+      }
+    }
+    String msg = String.format("Failed to get bom releases for environment %s due to null response", environmentName);
+    throw new OneOpsClientAPIException(msg);
+  }
+
+  /**
+   * Cancels a failed/paused deployment
+   * 
+   * @param environmentName
+   * @param deploymentId
+   * @param releaseId
+   * @return
+   * @throws OneOpsClientAPIException
+   */
+  public Deployment cancelDeployment(String assemblyName, String environmentName, Long deploymentId, Long releaseId) throws OneOpsClientAPIException {
+    return updateDeploymentStatus(assemblyName, environmentName, deploymentId, releaseId, "canceled");
+  }
+
+
+  public DeploymentRFC getDeployment(String assemblyName, String environmentName, Long deploymentId) throws OneOpsClientAPIException {
+    if (environmentName == null || environmentName.length() == 0) {
+      String msg = "Missing environment name to fetch details";
+      throw new OneOpsClientAPIException(msg);
+    }
+
+    if (deploymentId == null) {
+      String msg = "Missing deployment Id to fetch details";
+      throw new OneOpsClientAPIException(msg);
+    }
+
+    RequestSpecification request = createRequest();
+    Response response = request.get(transitionEnvUri(assemblyName) + environmentName + IConstants.DEPLOYMENTS_URI + deploymentId);
+    if (response != null) {
+      if (response.getStatusCode() == 200 || response.getStatusCode() == 302) {
+        return response.getBody().as(DeploymentRFC.class);
+      } else {
+        String msg = String.format("Failed to get deployment details for environment %s for id %s due to %s", environmentName, deploymentId, response.getStatusLine());
+        throw new OneOpsClientAPIException(msg);
+      }
+    }
+    String msg = String.format("Failed to get deployment details for environment %s for id %s due to null response", environmentName, deploymentId);
+    throw new OneOpsClientAPIException(msg);
+  }
+
+  public Log getDeploymentRfcLog(String assemblyName, String environmentName, Long deploymentId, Long rfcId) throws OneOpsClientAPIException {
+    if (environmentName == null || environmentName.length() == 0) {
+      String msg = "Missing environment name to fetch details";
+      throw new OneOpsClientAPIException(msg);
+    }
+
+    if (deploymentId == null) {
+      String msg = "Missing deployment Id to fetch details";
+      throw new OneOpsClientAPIException(msg);
+    }
+
+    if (rfcId == null) {
+      String msg = "Missing rfc Id to fetch details";
+      throw new OneOpsClientAPIException(msg);
+    }
+
+    RequestSpecification request = createRequest();
+    Response response = request.queryParam("rfcId", rfcId).get(transitionEnvUri(assemblyName) + environmentName + IConstants.DEPLOYMENTS_URI + deploymentId + "/log_data");
+    if (response != null) {
+      if (response.getStatusCode() == 200 || response.getStatusCode() == 302) {
+        return response.getBody().as(Log.class);
+      } else {
+        String msg = String.format("Failed to get deployment logs for environment %s, deployment id %s and rfcId %s due to %s", environmentName, deploymentId, rfcId, response.getStatusLine());
+        throw new OneOpsClientAPIException(msg);
+      }
+    }
+    String msg = String.format("Failed to get deployment logs for environment %s, deployment id %s and rfcId %s due to null response", environmentName, deploymentId, rfcId);
+    throw new OneOpsClientAPIException(msg);
+  }
+
+  /**
+   * Approve a deployment
+   * 
+   * @param environmentName
+   * @param deploymentId
+   * @param releaseId
+   * @return
+   * @throws OneOpsClientAPIException
+   */
+  public Deployment approveDeployment(String assemblyName, String environmentName, Long deploymentId, Long releaseId) throws OneOpsClientAPIException {
+    return updateDeploymentStatus(assemblyName, environmentName, deploymentId, releaseId, "active");
+  }
+
+  /**
+   * Retry a deployment
+   * 
+   * @param environmentName
+   * @param deploymentId
+   * @param releaseId
+   * @return
+   * @throws OneOpsClientAPIException
+   */
+  public Deployment retryDeployment(String assemblyName, String environmentName, Long deploymentId, Long releaseId) throws OneOpsClientAPIException {
+    return updateDeploymentStatus(assemblyName, environmentName, deploymentId, releaseId, "active");
+  }
+
+  /**
+   * Update deployment state
+   * 
+   * @param environmentName
+   * @param deploymentId
+   * @param releaseId
+   * @return
+   * @throws OneOpsClientAPIException
+   */
+  public Deployment updateDeploymentStatus(String assemblyName, String environmentName, Long deploymentId, Long releaseId, String newstate) throws OneOpsClientAPIException {
+    if (environmentName == null || environmentName.length() == 0) {
+      String msg = "Missing environment name to fetch details";
+      throw new OneOpsClientAPIException(msg);
+    }
+    if (deploymentId == null) {
+      String msg = "Missing deployment to fetch details";
+      throw new OneOpsClientAPIException(msg);
+    }
+
+    RequestSpecification request = createRequest();
+
+    Map<String, String> properties = new HashMap<String, String>();
+    properties.put("deploymentState", newstate);
+    properties.put("releaseId", String.valueOf(releaseId));
+    ResourceObject ro = new ResourceObject();
+    ro.setProperties(properties);
+    JSONObject jsonObject = JsonUtil.createJsonObject(ro, "cms_deployment");
+
+    Response response = request.body(jsonObject.toString()).put(transitionEnvUri(assemblyName) + environmentName + IConstants.DEPLOYMENTS_URI + deploymentId);
+    if (response != null) {
+      if (response.getStatusCode() == 200 || response.getStatusCode() == 302) {
+        return response.getBody().as(Deployment.class);
+      } else {
+        String msg = String.format("Failed to update deployment state to %s for environment %s with deployment Id %s due to %s", newstate, environmentName, deploymentId, response.getStatusLine());
+        throw new OneOpsClientAPIException(msg);
+      }
+    }
+    String msg = String.format("Failed to update deployment state to %s for environment %s with deployment Id %s due to null response", newstate, environmentName, deploymentId);
+    throw new OneOpsClientAPIException(msg);
+  }
+
+  /**
+   * Deletes the given environment
+   * 
+   * @param environmentName
+   * @return
+   * @throws OneOpsClientAPIException
+   */
+  public CiResource deleteEnvironment(String assemblyName, String environmentName) throws OneOpsClientAPIException {
+    if (environmentName == null || environmentName.length() == 0) {
+      String msg = "Missing environment name to delete";
+      throw new OneOpsClientAPIException(msg);
+    }
+
+    RequestSpecification request = createRequest();
+    Response response = request.delete(transitionEnvUri(assemblyName) + environmentName);
+    if (response != null) {
+      if (response.getStatusCode() == 200 || response.getStatusCode() == 302) {
+        return response.getBody().as(CiResource.class);
+      } else {
+        String msg = String.format("Failed to delete environment with name %s due to %s", environmentName, response.getStatusLine());
+        throw new OneOpsClientAPIException(msg);
+      }
+    }
+    String msg = String.format("Failed to delete environment with name %s due to null response", environmentName);
+    throw new OneOpsClientAPIException(msg);
+  }
+
+  /**
+   * List platforms for a given assembly/environment
+   * 
+   * @param environmentName
+   * @return
+   * @throws OneOpsClientAPIException
+   */
+  public List<CiResource> listPlatforms(String assemblyName, String environmentName) throws OneOpsClientAPIException {
+    if (environmentName == null || environmentName.length() == 0) {
+      String msg = "Missing environment name list platforms";
+      throw new OneOpsClientAPIException(msg);
+    }
+
+    RequestSpecification request = createRequest();
+    Response response = request.get(transitionEnvUri(assemblyName) + environmentName + IConstants.PLATFORM_URI);
+    if (response != null) {
+      if (response.getStatusCode() == 200 || response.getStatusCode() == 302) {
+        return JsonUtil.toObject(response.getBody().asString(), new TypeReference<List<CiResource>>() {});
+      } else {
+        String msg = String.format("Failed to get list of environment platforms due to %s", response.getStatusLine());
+        throw new OneOpsClientAPIException(msg);
+      }
+    }
+    String msg = "Failed to get list of environment platforms due to null response";
+    throw new OneOpsClientAPIException(msg);
+  }
+
+  /**
+   * Get platform details for a given assembly/environment
+   * 
+   * @param environmentName
+   * @param platformName
+   * @return
+   * @throws OneOpsClientAPIException
+   */
+  public CiResource getPlatform(String assemblyName, String environmentName, String platformName) throws OneOpsClientAPIException {
+    if (environmentName == null || environmentName.length() == 0) {
+      String msg = "Missing environment name to get details";
+      throw new OneOpsClientAPIException(msg);
+    }
+    if (platformName == null || platformName.length() == 0) {
+      String msg = "Missing platform name to get details";
+      throw new OneOpsClientAPIException(msg);
+    }
+    RequestSpecification request = createRequest();
+    Response response = request.get(transitionEnvUri(assemblyName) + environmentName + IConstants.PLATFORM_URI + platformName);
+    if (response != null) {
+      if (response.getStatusCode() == 200 || response.getStatusCode() == 302) {
+        return response.getBody().as(CiResource.class);
+      } else {
+        String msg = String.format("Failed to get environment platform details due to %s", response.getStatusLine());
+        throw new OneOpsClientAPIException(msg);
+      }
+    }
+    String msg = "Failed to get environment platform details due to null response";
+    throw new OneOpsClientAPIException(msg);
+  }
+
+  /**
+   * List platform components for a given assembly/environment/platform
+   * 
+   * @param environmentName
+   * @param platformName
+   * @return
+   * @throws OneOpsClientAPIException
+   */
+  public List<CiResource> listPlatformComponents(String assemblyName, String environmentName, String platformName) throws OneOpsClientAPIException {
+    if (environmentName == null || environmentName.length() == 0) {
+      String msg = "Missing environment name to list enviornment platform components";
+      throw new OneOpsClientAPIException(msg);
+    }
+    if (platformName == null || platformName.length() == 0) {
+      String msg = "Missing platform name to list enviornment platform components";
+      throw new OneOpsClientAPIException(msg);
+    }
+    RequestSpecification request = createRequest();
+    Response response = request.get(transitionEnvUri(assemblyName) + environmentName + IConstants.PLATFORM_URI + platformName + IConstants.COMPONENT_URI);
+    if (response != null) {
+      if (response.getStatusCode() == 200 || response.getStatusCode() == 302) {
+        return JsonUtil.toObject(response.getBody().asString(), new TypeReference<List<CiResource>>() {});
+      } else {
+        String msg = String.format("Failed to get list of environment platforms components due to %s", response.getStatusLine());
+        throw new OneOpsClientAPIException(msg);
+      }
+    }
+    String msg = "Failed to get list of environment platforms components due to null response";
+    throw new OneOpsClientAPIException(msg);
+  }
+
+  /**
+   * Get platform component details for a given assembly/environment/platform
+   * 
+   * @param environmentName
+   * @param platformName
+   * @param componentName
+   * @return
+   * @throws OneOpsClientAPIException
+   */
+  public CiResource getPlatformComponent(String assemblyName, String environmentName, String platformName, String componentName) throws OneOpsClientAPIException {
+    if (environmentName == null || environmentName.length() == 0) {
+      String msg = "Missing environment name to get enviornment platform component details";
+      throw new OneOpsClientAPIException(msg);
+    }
+    if (platformName == null || platformName.length() == 0) {
+      String msg = "Missing platform name to get enviornment platform component details";
+      throw new OneOpsClientAPIException(msg);
+    }
+    if (componentName == null || componentName.length() == 0) {
+      String msg = "Missing component name to get enviornment platform component details";
+      throw new OneOpsClientAPIException(msg);
+    }
+    RequestSpecification request = createRequest();
+    Response response = request.get(transitionEnvUri(assemblyName) + environmentName + IConstants.PLATFORM_URI + platformName + IConstants.COMPONENT_URI + componentName);
+    if (response != null) {
+      if (response.getStatusCode() == 200 || response.getStatusCode() == 302) {
+        return response.getBody().as(CiResource.class);
+      } else {
+        String msg = String.format("Failed to get enviornment platform component details due to %s", response.getStatusLine());
+        throw new OneOpsClientAPIException(msg);
+      }
+    }
+    String msg = "Failed to get enviornment platform component details due to null response";
+    throw new OneOpsClientAPIException(msg);
+  }
+
+  /**
+   * Update component attributes for a given assembly/environment/platform/component
+   * 
+   * @param environmentName
+   * @param platformName
+   * @param componentName
+   * @param attributes
+   * @return
+   * @throws OneOpsClientAPIException
+   */
+  public CiResource updatePlatformComponent(String assemblyName, String environmentName, String platformName, String componentName, Map<String, String> attributes) throws OneOpsClientAPIException {
+    if (environmentName == null || environmentName.length() == 0) {
+      String msg = "Missing environment name to update component attributes";
+      throw new OneOpsClientAPIException(msg);
+    }
+    if (platformName == null || platformName.length() == 0) {
+      String msg = "Missing platform name to update component attributes";
+      throw new OneOpsClientAPIException(msg);
+    }
+    if (componentName == null || componentName.length() == 0) {
+      String msg = "Missing component name to update component attributes";
+      throw new OneOpsClientAPIException(msg);
+    }
+    if (attributes == null || attributes.size() == 0) {
+      String msg = "Missing attributes list to be updated";
+      throw new OneOpsClientAPIException(msg);
+    }
+
+    CiResource componentDetails = getPlatformComponent(environmentName, platformName, componentName);
+    if (componentDetails != null) {
+      ResourceObject ro = new ResourceObject();
+
+      Long ciId = componentDetails.getCiId();
+
+      Map<String, String> attr = Maps.newHashMap();
+      //Add ciAttributes to be updated
+      if (attributes != null && attributes.size() > 0)
+        attr.putAll(attributes);
+
+      Map<String, String> ownerProps = Maps.newHashMap();
+      //Add existing attrProps to retain locking of attributes 
+      AttrProps attrProps = componentDetails.getAttrProps();
+      if (attrProps != null && attrProps.getAdditionalProperties() != null && attrProps.getAdditionalProperties().size() > 0 && attrProps.getAdditionalProperties().get("owner") != null) {
+        @SuppressWarnings("unchecked")
+        Map<String, String> ownersMap = (Map<String, String>) attrProps.getAdditionalProperties().get("owner");
+        for (Entry<String, String> entry : ownersMap.entrySet()) {
+          ownerProps.put(entry.getKey(), entry.getValue());
+        }
+      }
+
+      //Add updated attributes to attrProps to lock them
+      for (Entry<String, String> entry : attributes.entrySet()) {
+        ownerProps.put(entry.getKey(), "manifest");
+      }
+
+      ro.setAttributes(attr);
+      ro.setOwnerProps(ownerProps);
+
+      RequestSpecification request = createRequest();
+      JSONObject jsonObject = JsonUtil.createJsonObject(ro, "cms_dj_ci");
+      Response response = request.body(jsonObject.toString()).put(transitionEnvUri(assemblyName) + environmentName + IConstants.PLATFORM_URI + platformName + IConstants.COMPONENT_URI + ciId);
+      if (response != null) {
+        if (response.getStatusCode() == 200 || response.getStatusCode() == 302) {
+          return response.getBody().as(CiResource.class);
+        } else {
+          String msg = String.format("Failed to get update component %s due to %s", componentName, response.getStatusLine());
+          throw new OneOpsClientAPIException(msg);
+        }
+      }
+    }
+    String msg = String.format("Failed to get update component %s due to null response", componentName);
+    throw new OneOpsClientAPIException(msg);
+  }
+
+  /**
+   * touch component
+   * 
+   * @param environmentName
+   * @param platformName
+   * @param componentName
+   * @return
+   * @throws OneOpsClientAPIException
+   */
+  public CiResource touchPlatformComponent(String assemblyName, String environmentName, String platformName, String componentName) throws OneOpsClientAPIException {
+    if (environmentName == null || environmentName.length() == 0) {
+      String msg = "Missing environment name to update component attributes";
+      throw new OneOpsClientAPIException(msg);
+    }
+    if (platformName == null || platformName.length() == 0) {
+      String msg = "Missing platform name to update component attributes";
+      throw new OneOpsClientAPIException(msg);
+    }
+    if (componentName == null || componentName.length() == 0) {
+      String msg = "Missing component name to update component attributes";
+      throw new OneOpsClientAPIException(msg);
+    }
+
+    RequestSpecification request = createRequest();
+    JSONObject jo = new JSONObject();
+
+    Response response =
+      request.body(jo.toString()).post(transitionEnvUri(assemblyName) + environmentName + IConstants.PLATFORM_URI + platformName + IConstants.COMPONENT_URI + componentName + "/touch");
+
+    if (response != null) {
+      if (response.getStatusCode() == 200 || response.getStatusCode() == 302) {
+        return response.getBody().as(CiResource.class);
+      } else {
+        String msg = String.format("Failed to touch component %s due to %s", componentName, response.getStatusLine());
+        throw new OneOpsClientAPIException(msg);
+      }
+    }
+    String msg = String.format("Failed to get touch component %s due to null response", componentName);
+    throw new OneOpsClientAPIException(msg);
+  }
+
+  /**
+   * Pull latest design commits
+   * 
+   * @param environmentName {mandatory}
+   * @return
+   * @throws OneOpsClientAPIException
+   */
+  public CiResource pullDesign(String assemblyName, String environmentName) throws OneOpsClientAPIException {
+
+    RequestSpecification request = createRequest();
+    JSONObject jo = new JSONObject();
+
+    Response response = request.body(jo.toString()).post(transitionEnvUri(assemblyName) + environmentName + "/pull");
+    if (response != null) {
+      if (response.getStatusCode() == 200 || response.getStatusCode() == 302) {
+        CiResource env = response.getBody().as(CiResource.class);
+        if (env == null || (env.getComments() != null && env.getComments().startsWith("ERROR:"))) {
+          String msg = String.format("Failed to pull design for environment %s due to %s", environmentName, env.getComments());
+          throw new OneOpsClientAPIException(msg);
+        } else
+          return env;
+      } else {
+        String msg = String.format("Failed to pull design for environment %s due to %s", environmentName, response.getStatusLine());
+        throw new OneOpsClientAPIException(msg);
+      }
+    }
+    String msg = String.format("Failed to pull design for environment %s due to null response", environmentName);
+    throw new OneOpsClientAPIException(msg);
+  }
+
+  /**
+   * Use this pull design when new platform(s) or newer version of platform(s) is being added to the environment
+   *  
+   * @param environmentName
+   * @param platformAvailability
+   * @return
+   * @throws OneOpsClientAPIException
+   */
+  public CiResource pullNewPlatform(String assemblyName, String environmentName, Map<String, String> platformAvailability) throws OneOpsClientAPIException {
+
+    RequestSpecification request = createRequest();
+    JSONObject jo = new JSONObject();
+
+    if (platformAvailability == null || platformAvailability.size() == 0) {
+      List<CiResource> platforms = listPlatforms(assemblyName);
+
+      CiResource env = getEnvironment(assemblyName, environmentName);
+      String availability = "single";
+      if (env != null && env.getCiAttributes() != null) {
+        CiAttributes attr = env.getCiAttributes();//.availability");
+        if (attr.getAdditionalProperties() != null && attr.getAdditionalProperties().containsKey("availability")) {
+          availability = String.valueOf(attr.getAdditionalProperties().get("availability"));
+        }
+      }
+      if (platforms != null) {
+        platformAvailability = new HashMap<String, String>();
+        for (CiResource platform : platforms) {
+          platformAvailability.put(platform.getCiId() + "", availability);
+        }
+      }
+    }
+    jo.put("platform_availability", platformAvailability);
+
+    Response response = request.body(jo.toString()).post(transitionEnvUri(assemblyName) + environmentName + "/pull");
+    if (response != null) {
+      if (response.getStatusCode() == 200 || response.getStatusCode() == 302) {
+        CiResource env = response.getBody().as(CiResource.class);
+        if (env == null || (env.getComments() != null && env.getComments().startsWith("ERROR:"))) {
+          String msg = String.format("Failed to pull design for environment %s due to %s", environmentName, env.getComments());
+          throw new OneOpsClientAPIException(msg);
+        } else
+          return env;
+      } else {
+        String msg = String.format("Failed to pull design for environment %s due to %s", environmentName, response.getStatusLine());
+        throw new OneOpsClientAPIException(msg);
+      }
+    }
+    String msg = String.format("Failed to pull design for environment %s due to null response", environmentName);
+    throw new OneOpsClientAPIException(msg);
+  }
+
+  /**
+   * List local variables for a given assembly/environment/platform
+   * 
+   * @param environmentName
+   * @param platformName
+   * @return
+   * @throws OneOpsClientAPIException
+   */
+  public List<CiResource> listPlatformVariables(String assemblyName, String environmentName, String platformName) throws OneOpsClientAPIException {
+    if (environmentName == null || environmentName.length() == 0) {
+      String msg = "Missing environment name to list enviornment platform variables";
+      throw new OneOpsClientAPIException(msg);
+    }
+    if (platformName == null || platformName.length() == 0) {
+      String msg = "Missing platform name to list enviornment platform variables";
+      throw new OneOpsClientAPIException(msg);
+    }
+    RequestSpecification request = createRequest();
+    Response response = request.get(transitionEnvUri(assemblyName) + environmentName + IConstants.PLATFORM_URI + platformName + IConstants.VARIABLES_URI);
+    if (response != null) {
+      if (response.getStatusCode() == 200 || response.getStatusCode() == 302) {
+        return JsonUtil.toObject(response.getBody().asString(), new TypeReference<List<CiResource>>() {});
+      } else {
+        String msg = String.format("Failed to get list of environment platforms variables due to %s", response.getStatusLine());
+        throw new OneOpsClientAPIException(msg);
+      }
+    }
+    String msg = "Failed to get list of environment platforms variables due to null response";
+    throw new OneOpsClientAPIException(msg);
+  }
+
+  /**
+   * Update platform local variables for a given assembly/environment/platform
+   * 
+   * @param environmentName
+   * @param platformName
+   * @param variables
+   * @param isSecure
+   * @return
+   * @throws OneOpsClientAPIException
+   */
+
+  public Boolean updatePlatformVariable(String assemblyName, String environmentName, String platformName, String variableName, String variableValue, boolean isSecure) throws OneOpsClientAPIException {
+    if (environmentName == null || environmentName.length() == 0) {
+      String msg = "Missing environment name to update variables";
+      throw new OneOpsClientAPIException(msg);
+    }
+    if (platformName == null || platformName.length() == 0) {
+      String msg = "Missing platform name to update variables";
+      throw new OneOpsClientAPIException(msg);
+    }
+    if (variableName == null) {
+      String msg = "Missing variable name to be added";
+      throw new OneOpsClientAPIException(msg);
+    }
+    if (variableValue == null) {
+      String msg = "Missing variable value to be added";
+      throw new OneOpsClientAPIException(msg);
+    }
+
+    RequestSpecification request = createRequest();
+    boolean success = false;
+    ResourceObject ro = new ResourceObject();
+    Map<String, String> attributes = new HashMap<String, String>();
+
+    String uri = transitionEnvUri(assemblyName) + environmentName + IConstants.PLATFORM_URI + platformName + IConstants.VARIABLES_URI + variableName;
+    Response response = request.get(uri);
+    if (response != null) {
+      JSONObject var = JsonUtil.createJsonObject(response.getBody().asString());
+      if (var != null && var.has("ciAttributes")) {
+        JSONObject attrs = var.getJSONObject("ciAttributes");
+        for (Object key : attrs.keySet()) {
+          //based on you key types
+          String keyStr = (String) key;
+          String keyvalue = String.valueOf(attrs.get(keyStr));
+
+          attributes.put(keyStr, keyvalue);
+        }
+        if (isSecure) {
+          attributes.put("secure", "true");
+          attributes.put("encrypted_value", variableValue);
+        } else {
+          attributes.put("secure", "false");
+          attributes.put("value", variableValue);
+        }
+        ro.setAttributes(attributes);
+
+        JSONObject jsonObject = JsonUtil.createJsonObject(ro, "cms_dj_ci");
+        if (response != null) {
+          response = request.body(jsonObject.toString()).put(uri);
+          if (response != null) {
+            if (response.getStatusCode() == 200 || response.getStatusCode() == 302) {
+              success = true;
+            } else {
+              String msg = String.format("Failed to get update variables %s due to %s", variableName, response.getStatusLine());
+              throw new OneOpsClientAPIException(msg);
+            }
+          }
+        }
+      } else {
+        success = true;
+      }
+    } else {
+      String msg = String.format("Failed to get update variables %s due to null response", variableName);
+      throw new OneOpsClientAPIException(msg);
+    }
+
+
+    return success;
+  }
+
+
+
+  /**
+   * List global variables for a given assembly/environment
+   * 
+   * @param environmentName
+   * @return
+   * @throws OneOpsClientAPIException
+   */
+  public List<CiResource> listGlobalVariables(String assemblyName, String environmentName) throws OneOpsClientAPIException {
+    if (environmentName == null || environmentName.length() == 0) {
+      String msg = "Missing environment name to list enviornment variables";
+      throw new OneOpsClientAPIException(msg);
+    }
+    RequestSpecification request = createRequest();
+    Response response = request.get(transitionEnvUri(assemblyName) + environmentName + IConstants.VARIABLES_URI);
+    if (response != null) {
+      if (response.getStatusCode() == 200 || response.getStatusCode() == 302) {
+        return JsonUtil.toObject(response.getBody().asString(), new TypeReference<List<CiResource>>() {});
+      } else {
+        String msg = String.format("Failed to get list of environment variables due to %s", response.getStatusLine());
+        throw new OneOpsClientAPIException(msg);
+      }
+    }
+    String msg = "Failed to get list of environment variables due to null response";
+    throw new OneOpsClientAPIException(msg);
+  }
+
+  /**
+   * Update global variables for a given assembly/environment
+   * 
+   * @param environmentName
+   * @param variables
+   * @return
+   * @throws OneOpsClientAPIException
+   */
+  public Boolean updateGlobalVariable(String assemblyName, String environmentName, String variableName, String variableValue, boolean isSecure) throws OneOpsClientAPIException {
+    if (environmentName == null || environmentName.length() == 0) {
+      String msg = "Missing environment name to update component attributes";
+      throw new OneOpsClientAPIException(msg);
+    }
+    if (variableName == null) {
+      String msg = "Missing variable name to be added";
+      throw new OneOpsClientAPIException(msg);
+    }
+    if (variableValue == null) {
+      String msg = "Missing variable value to be added";
+      throw new OneOpsClientAPIException(msg);
+    }
+    boolean success = false;
+    RequestSpecification request = createRequest();
+    ResourceObject ro = new ResourceObject();
+    Map<String, String> attributes = new HashMap<String, String>();
+
+    String uri = transitionEnvUri(assemblyName) + environmentName + IConstants.VARIABLES_URI + variableName;
+    Response response = request.get(uri);
+    if (response != null) {
+      JSONObject var = JsonUtil.createJsonObject(response.getBody().asString());
+      if (var != null && var.has("ciAttributes")) {
+        JSONObject attrs = var.getJSONObject("ciAttributes");
+        for (Object key : attrs.keySet()) {
+          //based on you key types
+          String keyStr = (String) key;
+          String keyvalue = String.valueOf(attrs.get(keyStr));
+          attributes.put(keyStr, keyvalue);
+        }
+        if (isSecure) {
+          attributes.put("secure", "true");
+          attributes.put("encrypted_value", variableValue);
+        } else {
+          attributes.put("secure", "false");
+          attributes.put("value", variableValue);
+        }
+
+        ro.setAttributes(attributes);
+
+        JSONObject jsonObject = JsonUtil.createJsonObject(ro, "cms_dj_ci");
+        response = request.body(jsonObject.toString()).put(uri);
+        if (response != null) {
+          if (response.getStatusCode() == 200 || response.getStatusCode() == 302) {
+            success = true;
+          } else {
+            String msg = String.format("Failed to get update variables %s due to %s", variableName, response.getStatusLine());
+            throw new OneOpsClientAPIException(msg);
+          }
+        }
+      } else {
+        success = true;
+      }
+    } else {
+      String msg = String.format("Failed to get update variables %s due to null response", variableName);
+      throw new OneOpsClientAPIException(msg);
+    }
+
+
+
+    return success;
+  }
+
+  /**
+   * Mark the input {#platformIdList} platforms for delete
+   * 
+   * @param environmentName
+   * @param platformIdList
+   * @return
+   * @throws OneOpsClientAPIException
+   */
+  public CiResource updateDisableEnvironment(String assemblyName, String environmentName, List<String> platformIdList) throws OneOpsClientAPIException {
+    if (environmentName == null || environmentName.length() == 0) {
+      String msg = "Missing environment name to disable platforms";
+      throw new OneOpsClientAPIException(msg);
+    }
+
+    if (platformIdList == null || platformIdList.size() == 0) {
+      String msg = "Missing platforms list to be disabled";
+      throw new OneOpsClientAPIException(msg);
+    }
+
+    RequestSpecification request = createRequest();
+    JSONObject jsonObject = new JSONObject();
+    jsonObject.put("platformCiIds", platformIdList);
+
+    Response response = request.body(jsonObject.toString()).put(transitionEnvUri(assemblyName) + environmentName + "/disable");
+    if (response != null) {
+      if (response.getStatusCode() == 200 || response.getStatusCode() == 302) {
+        return response.getBody().as(CiResource.class);
+      } else {
+        String msg = String.format("Failed to disable platforms for environment with name %s due to %s", environmentName, response.getStatusLine());
+        throw new OneOpsClientAPIException(msg);
+      }
+    }
+    String msg = String.format("Failed to disable platforms for environment with name %s due to null response", environmentName);
+    throw new OneOpsClientAPIException(msg);
+  }
+
+  /**
+   * Update redundancy configuration for a given platform
+   * 
+   * @param environmentName
+   * @param platformName
+   * @param config update any 
+   * @return
+   * @throws OneOpsClientAPIException
+   */
+  public Boolean updatePlatformRedundancyConfig(String assemblyName, String environmentName, String platformName, String componentName, RedundancyConfig config) throws OneOpsClientAPIException {
+    if (environmentName == null || environmentName.length() == 0) {
+      String msg = "Missing environment name to be updated";
+      throw new OneOpsClientAPIException(msg);
+    }
+
+    if (platformName == null || platformName.length() == 0) {
+      String msg = "Missing platform name to be updated";
+      throw new OneOpsClientAPIException(msg);
+    }
+
+    if (config == null) {
+      String msg = "Missing redundancy config to be updated";
+      throw new OneOpsClientAPIException(msg);
+    }
+
+    RequestSpecification request = createRequest();
+
+    JSONObject redundant = new JSONObject();
+    redundant.put("max", config.getMax());
+    redundant.put("pct_dpmt", config.getPercentDeploy());
+    redundant.put("step_down", config.getStepDown());
+    redundant.put("flex", "true");
+    redundant.put("converge", "false");
+    redundant.put("min", config.getMin());
+    redundant.put("current", config.getCurrent());
+    redundant.put("step_up", config.getStepUp());
+    JSONObject rconfig = new JSONObject();
+    rconfig.put("relationAttributes", redundant);
+
+    redundant = new JSONObject();
+    redundant.put("max", "manifest");
+    redundant.put("pct_dpmt", "manifest");
+    redundant.put("step_down", "manifest");
+    redundant.put("flex", "manifest");
+    redundant.put("converge", "manifest");
+    redundant.put("min", "manifest");
+    redundant.put("current", "manifest");
+    redundant.put("step_up", "manifest");
+    JSONObject owner = new JSONObject();
+    owner.put("owner", redundant);
+
+    rconfig.put("relationAttrProps", owner);
+    if (componentName == null || componentName.isEmpty()) {
+      componentName = "compute";
+    }
+    CiResource componentDetails = getPlatformComponent(environmentName, platformName, componentName);
+    JSONObject jo = new JSONObject();
+    jo.put(String.valueOf(componentDetails.getCiId()), rconfig);
+
+    JSONObject dependsOn = new JSONObject();
+    dependsOn.put("depends_on", jo);
+
+    Response response = request.body(dependsOn.toString()).put(transitionEnvUri(assemblyName) + environmentName + IConstants.PLATFORM_URI + platformName);
+    if (response != null) {
+      if (response.getStatusCode() == 200 || response.getStatusCode() == 302) {
+        return true;
+      } else {
+        String msg = String.format("Failed to update platforms redundancy for environment with name %s due to %s", environmentName, response.getStatusLine());
+        throw new OneOpsClientAPIException(msg);
+      }
+    }
+    String msg = String.format("Failed to update platforms redundancy for environment with name %s due to null response", environmentName);
+    throw new OneOpsClientAPIException(msg);
+  }
+
+  public CiResource updatePlatformCloudScale(String assemblyName, String environmentName, String platformName, String cloudId, Map<String, String> cloudMap) throws OneOpsClientAPIException {
+    if (environmentName == null || environmentName.length() == 0) {
+      String msg = String.format("Missing environment name to be updated");
+      throw new OneOpsClientAPIException(msg);
+    }
+
+    if (platformName == null || platformName.length() == 0) {
+      String msg = String.format("Missing platform name to be updated");
+      throw new OneOpsClientAPIException(msg);
+    }
+
+    if (cloudId == null || cloudId.length() == 0) {
+      String msg = String.format("Missing cloud ID to be updated");
+      throw new OneOpsClientAPIException(msg);
+    }
+
+    if (cloudMap == null || cloudMap.size() == 0) {
+      String msg = String.format("Missing cloud info to be updated");
+      throw new OneOpsClientAPIException(msg);
+    }
+
+    RequestSpecification request = createRequest();
+    JSONObject jo = new JSONObject();
+    jo.put("cloud_id", cloudId);
+    jo.put("attributes", cloudMap);
+    Response response = request.body(jo.toString())
+      .put(transitionEnvUri(assemblyName) + environmentName + IConstants.PLATFORM_URI + platformName + "/cloud_configuration");
+    if (response != null) {
+      if (response.getStatusCode() == 200 || response.getStatusCode() == 302) {
+        return response.getBody().as(CiResource.class);
+      } else {
+        String msg = String.format("Failed to update platforms cloud scale with cloud id %s due to %s", cloudId,
+          response.getStatusLine());
+        throw new OneOpsClientAPIException(msg);
+      }
+    }
+    String msg = String.format("Failed to update platforms cloud scale with cloud id %s due to null response",
+      cloudId);
+    throw new OneOpsClientAPIException(msg);
+  }
+
+  /**
+   * List relays
+   * 
+   * @param environmentName
+   * @return
+   * @throws OneOpsClientAPIException
+   */
+  public List<CiResource> listRelays(String assemblyName, String environmentName) throws OneOpsClientAPIException {
+    if (environmentName == null || environmentName.length() == 0) {
+      String msg = "Missing environment name to get relays";
+      throw new OneOpsClientAPIException(msg);
+    }
+
+    RequestSpecification request = createRequest();
+    Response response = request.get(transitionEnvUri(assemblyName) + environmentName + "/relays/");
+    if (response != null) {
+      if (response.getStatusCode() == 200 || response.getStatusCode() == 302) {
+        return JsonUtil.toObject(response.getBody().asString(), new TypeReference<List<CiResource>>() {});
+      } else {
+        String msg = String.format("Failed to list relay due to %s", response.getStatusLine());
+        throw new OneOpsClientAPIException(msg);
+      }
+    }
+    String msg = "Failed to list relay due to null response";
+    throw new OneOpsClientAPIException(msg);
+  }
+
+  /**
+   * Get relay details
+   * 
+   * @param environmentName
+   * @param relayName
+   * @return
+   * @throws OneOpsClientAPIException
+   */
+
+  public CiResource getRelay(String assemblyName, String environmentName, String relayName) throws OneOpsClientAPIException {
+    if (environmentName == null || environmentName.length() == 0) {
+      String msg = "Missing environment name to get relay details";
+      throw new OneOpsClientAPIException(msg);
+    }
+
+    if (relayName == null || relayName.length() == 0) {
+      String msg = "Missing relay name to fetch details";
+      throw new OneOpsClientAPIException(msg);
+    }
+
+    RequestSpecification request = createRequest();
+    Response response = request.get(transitionEnvUri(assemblyName) + environmentName + "/relays/" + relayName);
+    if (response != null) {
+      if (response.getStatusCode() == 200 || response.getStatusCode() == 302) {
+        return response.getBody().as(CiResource.class);
+      } else {
+        String msg = String.format("Failed to get relay with name %s due to %s", relayName, response.getStatusLine());
+        throw new OneOpsClientAPIException(msg);
+      }
+    }
+    String msg = String.format("Failed to get relay with name %s due to null response", relayName);
+    throw new OneOpsClientAPIException(msg);
+  }
+
+  /**
+   * Add new Relay
+   * 
+   * @param relayName
+   * @param severity
+   * @param emails
+   * @param source
+   * @param nsPaths
+   * @param regex
+   * @param correlation
+   * @return
+   * @throws OneOpsClientAPIException
+   */
+  public CiResource addRelay(String assemblyName, String environmentName, String relayName, String severity, String emails, String source, String nsPaths, String regex, boolean correlation)
+    throws OneOpsClientAPIException {
+    if (environmentName == null || environmentName.length() == 0) {
+      String msg = "Missing environment name to create relay";
+      throw new OneOpsClientAPIException(msg);
+    }
+
+    ResourceObject ro = new ResourceObject();
+    Map<String, String> properties = Maps.newHashMap();
+
+    if (relayName == null || relayName.length() == 0) {
+      String msg = "Missing relay name to create one";
+      throw new OneOpsClientAPIException(msg);
+    }
+    if (emails == null || emails.length() == 0) {
+      String msg = "Missing emails addresses to create relay";
+      throw new OneOpsClientAPIException(msg);
+    }
+    if (severity == null || severity.length() == 0) {
+      String msg = "Missing severity to create relay";
+      throw new OneOpsClientAPIException(msg);
+    }
+    if (source == null || source.length() == 0) {
+      String msg = "Missing source to create relay";
+      throw new OneOpsClientAPIException(msg);
+    }
+
+
+    properties.put("ciName", relayName);
+    String path = "/" + instance.getOrgname() + "/" + assemblyName + "/" + environmentName;
+    properties.put("nsPath", path);
+
+    RequestSpecification request = createRequest();
+    ro.setProperties(properties);
+
+    Response newRelayResponse = request.get(transitionEnvUri(assemblyName) + environmentName + "/relays/new");
+    if (newRelayResponse != null) {
+      JsonPath attachmentDetails = newRelayResponse.getBody().jsonPath();
+      Map<String, String> attributes = attachmentDetails.getMap("ciAttributes");
+      if (attributes == null) {
+        attributes = Maps.newHashMap();
+      }
+      attributes.put("enabled", "true");
+      attributes.put("emails", emails);
+      if (!Strings.isNullOrEmpty(severity))
+        attributes.put("severity", severity);
+      if (!Strings.isNullOrEmpty(source))
+        attributes.put("source", source);
+      if (!Strings.isNullOrEmpty(nsPaths))
+        attributes.put("ns_paths", nsPaths);
+      if (!Strings.isNullOrEmpty(regex))
+        attributes.put("text_regex", regex);
+
+      attributes.put("correlation", String.valueOf(correlation));
+      ro.setAttributes(attributes);
+    }
+
+    JSONObject jsonObject = JsonUtil.createJsonObject(ro, "cms_ci");
+    Response response = request.body(jsonObject.toString()).post(transitionEnvUri(assemblyName) + environmentName + "/relays");
+
+    if (response != null) {
+      if (response.getStatusCode() == 200 || response.getStatusCode() == 302) {
+        return response.getBody().as(CiResource.class);
+      } else {
+        String msg = String.format("Failed to create relay with name %s due to %s", relayName, response.getStatusLine());
+        throw new OneOpsClientAPIException(msg);
+      }
+    }
+    String msg = String.format("Failed to create relay with name %s due to null response", relayName);
+    throw new OneOpsClientAPIException(msg);
+  }
+
+  /**
+   * Update relay
+   * 
+   * @param environmentName
+   * @param relayName
+   * @param severity
+   * @param emails
+   * @param source
+   * @param nsPaths
+   * @param regex
+   * @param correlation
+   * @param enable
+   * @return
+   * @throws OneOpsClientAPIException
+   */
+  public CiResource updateRelay(String assemblyName, String environmentName, String relayName, String severity, String emails, String source, String nsPaths, String regex, boolean correlation,
+    boolean enable) throws OneOpsClientAPIException {
+    if (environmentName == null || environmentName.length() == 0) {
+      String msg = "Missing environment name to create relay";
+      throw new OneOpsClientAPIException(msg);
+    }
+
+    ResourceObject ro = new ResourceObject();
+    Map<String, String> attributes = Maps.newHashMap();
+
+    if (relayName == null || relayName.length() == 0) {
+      String msg = "Missing relay name to update";
+      throw new OneOpsClientAPIException(msg);
+    }
+
+    RequestSpecification request = createRequest();
+
+    Response relayResponse = request.get(transitionEnvUri(assemblyName) + environmentName + "/relays/" + relayName);
+    if (relayResponse != null) {
+      JsonPath newVarJsonPath = relayResponse.getBody().jsonPath();
+      if (newVarJsonPath != null) {
+        attributes = newVarJsonPath.getMap("ciAttributes");
+        if (attributes == null) {
+          attributes = Maps.newHashMap();
+        } else {
+          attributes.put("enabled", String.valueOf(enable));
+          if (!Strings.isNullOrEmpty(emails))
+            attributes.put("emails", emails);
+          if (!Strings.isNullOrEmpty(severity))
+            attributes.put("severity", severity);
+          if (!Strings.isNullOrEmpty(source))
+            attributes.put("source", source);
+          if (!Strings.isNullOrEmpty(nsPaths))
+            attributes.put("ns_paths", nsPaths);
+          if (!Strings.isNullOrEmpty(regex))
+            attributes.put("text_regex", regex);
+        }
+      }
+    }
+    ro.setAttributes(attributes);
+
+    JSONObject jsonObject = JsonUtil.createJsonObject(ro, "cms_ci");
+
+    Response response = request.body(jsonObject.toString()).put(transitionEnvUri(assemblyName) + environmentName + "/relays/" + relayName);
+
+    if (response != null) {
+      if (response.getStatusCode() == 200 || response.getStatusCode() == 302) {
+        return response.getBody().as(CiResource.class);
+      } else {
+        String msg = String.format("Failed to update relay with name %s due to %s", relayName, response.getStatusLine());
+        throw new OneOpsClientAPIException(msg);
+      }
+    }
+    String msg = String.format("Failed to update relay with name %s due to null response", relayName);
+    throw new OneOpsClientAPIException(msg);
+  }
+
+  private String transitionEnvUri(String assemblyName) {
+    return IConstants.ASSEMBLY_URI + assemblyName + IConstants.TRANSITION_URI + IConstants.ENVIRONMENT_URI;
+  }
 }

--- a/src/main/java/com/oneops/api/OOInstance.java
+++ b/src/main/java/com/oneops/api/OOInstance.java
@@ -2,78 +2,97 @@ package com.oneops.api;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 
-@JsonIgnoreProperties(ignoreUnknown=true)
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class OOInstance {
 
-	private String name;
-	private String endpoint;
-	private String orgname;
-	private String authtoken;
-	private String assembly;
-	private String platform;
-	private String environment;
-	private String component;
-	private String comment;
-	private boolean gzipEnabled = true;
-	
-	public String getName() {
-		return name;
-	}
-	public void setName(String name) {
-		this.name = name;
-	}
-	public String getEndpoint() {
-		return endpoint;
-	}
-	public void setEndpoint(String endpoint) {
-		this.endpoint = endpoint;
-	}
-	public String getOrgname() {
-		return orgname;
-	}
-	public void setOrgname(String orgname) {
-		this.orgname = orgname;
-	}
-	public String getAuthtoken() {
-		return authtoken;
-	}
-	public void setAuthtoken(String authtoken) {
-		this.authtoken = authtoken;
-	}
-	public String getAssembly() {
-		return assembly;
-	}
-	public void setAssembly(String assembly) {
-		this.assembly = assembly;
-	}
-	public String getPlatform() {
-		return platform;
-	}
-	public void setPlatform(String platform) {
-		this.platform = platform;
-	}
-	public String getEnvironment() {
-		return environment;
-	}
-	public void setEnvironment(String environment) {
-		this.environment = environment;
-	}
-	public String getComponent() {
-		return component;
-	}
-	public void setComponent(String component) {
-		this.component = component;
-	}
-	public String getComment() {
-		return comment;
-	}
-	public void setComment(String comment) {
-		this.comment = comment;
-	}	
-	public boolean isGzipEnabled() {
-		return gzipEnabled;
-	}
-	public void setGzipEnabled(boolean gzipEnabled) {
-		this.gzipEnabled = gzipEnabled;
-	}
+  private String name;
+  private String endpoint;
+  private String orgname;
+  private String authtoken;
+  private String assembly;
+  private String platform;
+  private String environment;
+  private String component;
+  private String comment;
+  private boolean gzipEnabled = true;
+
+  public String getName() {
+    return name;
+  }
+
+  public void setName(String name) {
+    this.name = name;
+  }
+
+  public String getEndpoint() {
+    return endpoint;
+  }
+
+  public void setEndpoint(String endpoint) {
+    this.endpoint = endpoint;
+  }
+
+  public String getOrgname() {
+    return orgname;
+  }
+
+  public void setOrgname(String orgname) {
+    this.orgname = orgname;
+  }
+
+  public String getAuthtoken() {
+    return authtoken;
+  }
+
+  public void setAuthtoken(String authtoken) {
+    this.authtoken = authtoken;
+  }
+
+  public String getAssembly() {
+    return assembly;
+  }
+
+  public void setAssembly(String assembly) {
+    this.assembly = assembly;
+  }
+
+  public String getPlatform() {
+    return platform;
+  }
+
+  public void setPlatform(String platform) {
+    this.platform = platform;
+  }
+
+  public String getEnvironment() {
+    return environment;
+  }
+
+  public void setEnvironment(String environment) {
+    this.environment = environment;
+  }
+
+  public String getComponent() {
+    return component;
+  }
+
+  public void setComponent(String component) {
+    this.component = component;
+  }
+
+  public String getComment() {
+    return comment;
+  }
+
+  public void setComment(String comment) {
+    this.comment = comment;
+  }
+
+  public boolean isGzipEnabled() {
+    return gzipEnabled;
+  }
+
+  public void setGzipEnabled(boolean gzipEnabled) {
+    this.gzipEnabled = gzipEnabled;
+  }
 }

--- a/src/main/java/com/oneops/api/ResourceObject.java
+++ b/src/main/java/com/oneops/api/ResourceObject.java
@@ -3,26 +3,31 @@ package com.oneops.api;
 import java.util.Map;
 
 public class ResourceObject {
-	private Map<String ,String> attributes;
-	private Map<String ,String> ownerProps;
-	private Map<String ,String> properties;
-	
-	public Map<String, String> getProperties() {
-		return properties;
-	}
-	public void setProperties(Map<String, String> properties) {
-		this.properties = properties;
-	}
-	public Map<String, String> getOwnerProps() {
-		return ownerProps;
-	}
-	public void setOwnerProps(Map<String, String> ownerProps) {
-		this.ownerProps = ownerProps;
-	}
-	public Map<String, String> getAttributes() {
-		return attributes;
-	}
-	public void setAttributes(Map<String, String> attributes) {
-		this.attributes = attributes;
-	}
+  private Map<String, String> attributes;
+  private Map<String, String> ownerProps;
+  private Map<String, String> properties;
+
+  public Map<String, String> getProperties() {
+    return properties;
+  }
+
+  public void setProperties(Map<String, String> properties) {
+    this.properties = properties;
+  }
+
+  public Map<String, String> getOwnerProps() {
+    return ownerProps;
+  }
+
+  public void setOwnerProps(Map<String, String> ownerProps) {
+    this.ownerProps = ownerProps;
+  }
+
+  public Map<String, String> getAttributes() {
+    return attributes;
+  }
+
+  public void setAttributes(Map<String, String> attributes) {
+    this.attributes = attributes;
+  }
 }

--- a/src/main/java/com/oneops/api/exception/OneOpsClientAPIException.java
+++ b/src/main/java/com/oneops/api/exception/OneOpsClientAPIException.java
@@ -2,28 +2,28 @@ package com.oneops.api.exception;
 
 public class OneOpsClientAPIException extends Exception {
 
-	/**
-	 * 
-	 */
-	private static final long serialVersionUID = 1L;
+  /**
+   * 
+   */
+  private static final long serialVersionUID = 1L;
 
-	public OneOpsClientAPIException() {
-		super();
-	}
+  public OneOpsClientAPIException() {
+    super();
+  }
 
-	public OneOpsClientAPIException(String message) {
-		super(message);
-		// TODO Auto-generated constructor stub
-	}
+  public OneOpsClientAPIException(String message) {
+    super(message);
+    // TODO Auto-generated constructor stub
+  }
 
-	public OneOpsClientAPIException(Throwable cause) {
-		super(cause);
-		// TODO Auto-generated constructor stub
-	}
+  public OneOpsClientAPIException(Throwable cause) {
+    super(cause);
+    // TODO Auto-generated constructor stub
+  }
 
-	public OneOpsClientAPIException(String message, Throwable cause) {
-		super(message, cause);
-		// TODO Auto-generated constructor stub
-	}
+  public OneOpsClientAPIException(String message, Throwable cause) {
+    super(message, cause);
+    // TODO Auto-generated constructor stub
+  }
 
 }

--- a/src/main/java/com/oneops/api/resource/Account.java
+++ b/src/main/java/com/oneops/api/resource/Account.java
@@ -2,155 +2,42 @@ package com.oneops.api.resource;
 
 import java.util.List;
 
-import org.json.JSONObject;
-
-import com.fasterxml.jackson.core.type.TypeReference;
 import com.jayway.restassured.path.json.JsonPath;
-import com.jayway.restassured.response.Response;
-import com.jayway.restassured.specification.RequestSpecification;
 import com.oneops.api.APIClient;
 import com.oneops.api.OOInstance;
 import com.oneops.api.exception.OneOpsClientAPIException;
 import com.oneops.api.resource.model.Organization;
-import com.oneops.api.util.IConstants;
-import com.oneops.api.util.JsonUtil;
 
+@Deprecated
 public class Account extends APIClient {
 
-	public Account(OOInstance instance) throws OneOpsClientAPIException {
-		super(instance);
-	}
-	
-	/**
-	 * Lists all the organizations
-	 * 
-	 * @return
-	 * @throws OneOpsClientAPIException
-	 */
-	public List<Organization> listOrganizations() throws OneOpsClientAPIException {
-		RequestSpecification request = createRequest();
-		Response response = request.get(IConstants.ACCOUNT_URI);
-		if(response != null) {
-			if(response.getStatusCode() == 200 || response.getStatusCode() == 302) {
-				return JsonUtil.toObject(response.getBody().asString(), new TypeReference<List<Organization>>(){});
-			} else {
-				String msg = String.format("Failed to get list of organizations due to %s", response.getStatusLine());
-				throw new OneOpsClientAPIException(msg);
-			}
-		} 
-		String msg = "Failed to get list of organizations due to null response";
-		throw new OneOpsClientAPIException(msg);
-	}
-	
-	/**
-	 * Fetches specific organization details
-	 * 
-	 * @param organizationName
-	 * @return
-	 * @throws OneOpsClientAPIException
-	 */
-	public Organization getOrganization(String organizationName) throws OneOpsClientAPIException {
-		if(organizationName == null || organizationName.length() == 0) {
-			String msg = "Missing organization name to fetch details";
-			throw new OneOpsClientAPIException(msg);
-		}
-		
-		RequestSpecification request = createRequest();
-		Response response = request.get(IConstants.ACCOUNT_URI + organizationName);
-		if(response != null) {
-			if(response.getStatusCode() == 200 || response.getStatusCode() == 302) {
-				return response.getBody().as(Organization.class);
-			} else {
-				String msg = String.format("Failed to get organization with name %s due to %s", organizationName, response.getStatusLine());
-				throw new OneOpsClientAPIException(msg);
-			}
-		} 
-		String msg = String.format("Failed to get organization with name %s due to null response", organizationName);
-		throw new OneOpsClientAPIException(msg);
-	}
-	
-	/**
-	 * Creates organization for the given @organizationName
-	 * 
-	 * @param organizationName {mandatory} 
-	 * @return
-	 * @throws OneOpsClientAPIException
-	 */
-	public Organization createOrganization(String organizationName) throws OneOpsClientAPIException {
-		if(organizationName == null || organizationName.length() == 0) {
-			String msg = "Missing organization name to create one";
-			throw new OneOpsClientAPIException(msg);
-		}
-		RequestSpecification request = createRequest();
-		JSONObject jsonObject = new JSONObject();
-		jsonObject.put("name", organizationName);
-		Response response = request.body(jsonObject.toString()).post(IConstants.ACCOUNT_URI);
-		
-		if(response != null) {
-			if(response.getStatusCode() == 200 || response.getStatusCode() == 302) {
-				return response.getBody().as(Organization.class);
-			} else {
-				String msg = String.format("Failed to create organization with name %s due to %s", organizationName, response.getStatusLine());
-				throw new OneOpsClientAPIException(msg);
-			}
-		} 
-		String msg = String.format("Failed to create organization with name %s due to null response", organizationName);
-		throw new OneOpsClientAPIException(msg);
-	}
-	
-	/**
-	 * Deletes the given organization
-	 * 
-	 * @param organizationName
-	 * @return
-	 * @throws OneOpsClientAPIException
-	 */
-	public Organization deleteOrganization(String organizationName) throws OneOpsClientAPIException {
-		if(organizationName == null || organizationName.length() == 0) {
-			String msg = "Missing organization name to delete one";
-			throw new OneOpsClientAPIException(msg);
-		}
-		
-		RequestSpecification request = createRequest();
-		Organization org = getOrganization(organizationName);
-		Long id =  org.getId();
-		if(id == null) {
-			String msg = String.format("Failed to find organization with name %s to delete", organizationName);
-			throw new OneOpsClientAPIException(msg);
-		} 
-		
-		Response response = request.delete(IConstants.ACCOUNT_URI + id);
-		if(response != null) {
-			if(response.getStatusCode() == 200 || response.getStatusCode() == 302) {
-				return response.getBody().as(Organization.class);
-			} else {
-				String msg = String.format("Failed to delete organization with name %s due to %s", organizationName, response.getStatusLine());
-				throw new OneOpsClientAPIException(msg);
-			}
-		} 
-		String msg = String.format("Failed to delete organization with name %s due to null response", organizationName);
-		throw new OneOpsClientAPIException(msg);
-	}
-	
-	/**
-	 * Lists all the Environment Profiles
-	 * 
-	 * @return
-	 * @throws OneOpsClientAPIException
-	 */
-	public JsonPath listEnvironmentProfiles() throws OneOpsClientAPIException {
-		RequestSpecification request = createRequest();
-		Response response = request.get(IConstants.ORGANIZATION_URI + "environments");
-		if(response != null) {
-			if(response.getStatusCode() == 200 || response.getStatusCode() == 302) {
-				return response.getBody().jsonPath();
-			} else {
-				String msg = String.format("Failed to get list of Environment Profiles due to %s", response.getStatusLine());
-				throw new OneOpsClientAPIException(msg);
-			}
-		} 
-		String msg = "Failed to get list of Environment Profiles due to null response";
-		throw new OneOpsClientAPIException(msg);
-	}
+  @Deprecated
+  public Account(OOInstance instance) throws OneOpsClientAPIException {
+    super(instance);
+  }
 
+  @Deprecated
+  public List<Organization> listOrganizations() throws OneOpsClientAPIException {
+    return super.listOrganizations();
+  }
+
+  @Deprecated
+  public Organization getOrganization(String organizationName) throws OneOpsClientAPIException {
+    return super.getOrganization(organizationName);
+  }
+
+  @Deprecated
+  public Organization createOrganization(String organizationName) throws OneOpsClientAPIException {
+    return super.createOrganization(organizationName);
+  }
+
+  @Deprecated
+  public Organization deleteOrganization(String organizationName) throws OneOpsClientAPIException {
+    return super.deleteOrganization(organizationName);
+  }
+
+  @Deprecated
+  public JsonPath listEnvironmentProfiles() throws OneOpsClientAPIException {
+    return super.listEnvironmentProfiles();
+  }
 }

--- a/src/main/java/com/oneops/api/resource/Assembly.java
+++ b/src/main/java/com/oneops/api/resource/Assembly.java
@@ -1,232 +1,48 @@
 package com.oneops.api.resource;
 
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.json.JSONObject;
-
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.jayway.restassured.response.Response;
-import com.jayway.restassured.specification.RequestSpecification;
 import com.oneops.api.APIClient;
 import com.oneops.api.OOInstance;
-import com.oneops.api.ResourceObject;
 import com.oneops.api.exception.OneOpsClientAPIException;
 import com.oneops.api.resource.model.CiResource;
-import com.oneops.api.util.IConstants;
-import com.oneops.api.util.JsonUtil;
 
+@Deprecated
 public class Assembly extends APIClient {
 
-	public Assembly(OOInstance instance) throws OneOpsClientAPIException {
-		super(instance);
-	}
-	
-	/**
-	 * Fetches specific assembly details
-	 * 
-	 * @param assemblyName
-	 * @return
-	 * @throws OneOpsClientAPIException
-	 */
-	public CiResource getAssembly(String assemblyName) throws OneOpsClientAPIException {
-		if(assemblyName == null || assemblyName.length() == 0) {
-			String msg = "Missing assembly name to fetch details";
-			throw new OneOpsClientAPIException(msg);
-		}
-		
-		RequestSpecification request = createRequest();
-		Response response = request.get(IConstants.ASSEMBLY_URI + assemblyName);
-		if(response != null) {
-			if(response.getStatusCode() == 200 || response.getStatusCode() == 302) {
-				return response.getBody().as(CiResource.class);
-			} else {
-				String msg = String.format("Failed to get assembly with name %s due to %s", assemblyName, response.getStatusLine());
-				throw new OneOpsClientAPIException(msg);
-			}
-		} 
-		String msg = String.format("Failed to get assembly with name %s due to null response", assemblyName);
-		throw new OneOpsClientAPIException(msg);
-	}
-	
-	/**
-	 * Lists all the assemblies
-	 * 
-	 * @return
-	 * @throws OneOpsClientAPIException
-	 */
-	public List<CiResource> listAssemblies() throws OneOpsClientAPIException {
-		RequestSpecification request = createRequest();
-		Response response = request.get(IConstants.ASSEMBLY_URI);
-		if(response != null) {
-			if(response.getStatusCode() == 200 || response.getStatusCode() == 302) {
-				return JsonUtil.toObject(response.getBody().asString(), new TypeReference<List<CiResource>>(){});
-			} else {
-				String msg = String.format("Failed to get list of assemblies due to %s", response.getStatusLine());
-				throw new OneOpsClientAPIException(msg);
-			}
-		} 
-		String msg = "Failed to get list of assemblies due to null response";
-		throw new OneOpsClientAPIException(msg);
-	}
-	
-	
-	/**
-	 * Creates assembly for the given @assemblyName
-	 * 
-	 * @param assemblyName {mandatory} 
-	 * @param ownerEmail a valid email address is {mandatory}
-	 * @param comments
-	 * @param description
-	 * @return
-	 * @throws OneOpsClientAPIException
-	 */
-	public CiResource createAssembly(String assemblyName, String ownerEmail, String comments, String description) throws OneOpsClientAPIException {
-		return createAssembly(assemblyName, ownerEmail, comments, description, null);
-	}
-	
-	/**
-	 * Creates assembly for the given @assemblyName
-	 * 
-	 * @param assemblyName {mandatory} 
-	 * @param ownerEmail a valid email address is {mandatory}
-	 * @param comments
-	 * @param description
-	 * @param tags
-	 * @return
-	 * @throws OneOpsClientAPIException
-	 */
-	public CiResource createAssembly(String assemblyName, String ownerEmail, String comments, String description, Map<String, String> tags) throws OneOpsClientAPIException {
-		ResourceObject ro = new ResourceObject();
-		Map<String ,String> attributes = new HashMap<String ,String>();
-		Map<String ,String> properties= new HashMap<String ,String>();
-		
-		if(assemblyName != null && assemblyName.length() > 0) {
-			properties.put("ciName", assemblyName);
-		} else {
-			String msg = "Missing assembly name to create one";
-			throw new OneOpsClientAPIException(msg);
-		}
-		
-		properties.put("comments", comments);
-		ro.setProperties(properties);
-		
-		if(ownerEmail != null && ownerEmail.length() > 0) {
-			attributes.put("owner", ownerEmail);
-		} else {
-			String msg = "Missing assembly owner email address";
-			throw new OneOpsClientAPIException(msg);
-		}
-		
-		attributes.put("description", description);
-		
-		if( tags != null && !tags.isEmpty() ){
-			attributes.put("tags", JSONObject.valueToString(tags));
-		}
-		
-		ro.setAttributes(attributes);
-		
-		RequestSpecification request = createRequest();
-		JSONObject jsonObject = JsonUtil.createJsonObject(ro , "cms_ci");
+  @Deprecated
+  public Assembly(OOInstance instance) throws OneOpsClientAPIException {
+    super(instance);
+  }
 
-		Response response = request.body(jsonObject.toString()).post(IConstants.ASSEMBLY_URI);
-		
-		if(response != null) {
-			if(response.getStatusCode() == 200 || response.getStatusCode() == 302) {
-				return response.getBody().as(CiResource.class);
-			} else {
-				String msg = String.format("Failed to create assembly with name %s due to %s", assemblyName, response.getStatusLine());
-				throw new OneOpsClientAPIException(msg);
-			}
-		} 
-		String msg = String.format("Failed to create assembly with name %s due to null response", assemblyName);
-		throw new OneOpsClientAPIException(msg);
-	}
-	
-	
-	/**
-	 * Updates assembly for the given @assemblyName
-	 * 
-	 * @param assemblyName {mandatory} 
-	 * @param ownerEmail a valid email address is {mandatory}
-	 * @param description
-	 * @param tags
-	 * @return
-	 * @throws OneOpsClientAPIException
-	 */
-	public CiResource updateAssembly(String assemblyName, String ownerEmail, String description, Map<String, String> tags) throws OneOpsClientAPIException {
-		ResourceObject ro = new ResourceObject();
-		Map<String ,String> attributes = new HashMap<String ,String>();
-		Map<String ,String> properties= new HashMap<String ,String>();
-		
-		if(assemblyName != null && assemblyName.length() > 0) {
-			properties.put("ciName", assemblyName);
-		} else {
-			String msg = "Missing assembly name to update one";
-			throw new OneOpsClientAPIException(msg);
-		}
-		
-		CiResource assembly = getAssembly(assemblyName);
-		
-		properties.put("ciId", String.valueOf(assembly.getCiId()));
-		ro.setProperties(properties);
-		
-		if(ownerEmail != null && ownerEmail.length() > 0) {
-			attributes.put("owner", ownerEmail);
-		}
-		
-		if(description != null && description.length() > 0) {
-			attributes.put("description", description);
-		}
-		
-		if( tags != null && !tags.isEmpty() ){
-			attributes.put("tags", JSONObject.valueToString(tags));
-		}
-		
-		ro.setAttributes(attributes);
-		
-		RequestSpecification request = createRequest();
-		JSONObject jsonObject = JsonUtil.createJsonObject(ro , "cms_ci");
+  @Deprecated
+  public CiResource getAssembly(String assemblyName) throws OneOpsClientAPIException {
+    return super.getAssembly(assemblyName);
+  }
 
-		Response response = request.body(jsonObject.toString()).put(IConstants.ASSEMBLY_URI + assemblyName);
-		
-		if(response != null) {
-			if(response.getStatusCode() == 200 || response.getStatusCode() == 302) {
-				return response.getBody().as(CiResource.class);
-			} else {
-				String msg = String.format("Failed to update assembly with name %s due to %s", assemblyName, response.getStatusLine());
-				throw new OneOpsClientAPIException(msg);
-			}
-		} 
-		String msg = String.format("Failed to update assembly with name %s due to null response", assemblyName);
-		throw new OneOpsClientAPIException(msg);
-	}
-	
-	/**
-	 * Deletes the given assembly
-	 * 
-	 * @param assemblyName
-	 * @return
-	 * @throws OneOpsClientAPIException
-	 */
-	public CiResource deleteAssembly(String assemblyName) throws OneOpsClientAPIException {
-		if(assemblyName == null || assemblyName.length() == 0) {
-			String msg = "Missing assembly name to delete one";
-			throw new OneOpsClientAPIException(msg);
-		}
-		
-		RequestSpecification request = createRequest();
-		Response response = request.delete(IConstants.ASSEMBLY_URI + assemblyName);
-		if(response != null) {
-			if(response.getStatusCode() == 200 || response.getStatusCode() == 302) {
-				return response.getBody().as(CiResource.class);
-			} else {
-				String msg = String.format("Failed to delete assembly with name %s due to %s", assemblyName, response.getStatusLine());
-				throw new OneOpsClientAPIException(msg);
-			}
-		} 
-		String msg = String.format("Failed to delete assembly with name %s due to null response", assemblyName);
-		throw new OneOpsClientAPIException(msg);
-	}
+  @Deprecated
+  public List<CiResource> listAssemblies() throws OneOpsClientAPIException {
+    return super.listAssemblies();
+  }
+
+  @Deprecated
+  public CiResource createAssembly(String assemblyName, String ownerEmail, String comments, String description) throws OneOpsClientAPIException {
+    return super.createAssembly(assemblyName, ownerEmail, comments, description);
+  }
+
+  @Deprecated
+  public CiResource createAssembly(String assemblyName, String ownerEmail, String comments, String description, Map<String, String> tags) throws OneOpsClientAPIException {
+    return super.createAssembly(assemblyName, ownerEmail, comments, description, tags);
+  }
+
+  @Deprecated
+  public CiResource updateAssembly(String assemblyName, String ownerEmail, String description, Map<String, String> tags) throws OneOpsClientAPIException {
+    return super.updateAssembly(assemblyName, ownerEmail, description, tags);
+  }
+
+  @Deprecated
+  public CiResource deleteAssembly(String assemblyName) throws OneOpsClientAPIException {
+    return super.deleteAssembly(assemblyName);
+  }
 }

--- a/src/main/java/com/oneops/api/resource/Cloud.java
+++ b/src/main/java/com/oneops/api/resource/Cloud.java
@@ -2,95 +2,30 @@ package com.oneops.api.resource;
 
 import java.util.List;
 
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.jayway.restassured.response.Response;
-import com.jayway.restassured.specification.RequestSpecification;
 import com.oneops.api.APIClient;
 import com.oneops.api.OOInstance;
 import com.oneops.api.exception.OneOpsClientAPIException;
 import com.oneops.api.resource.model.CiResource;
-import com.oneops.api.util.IConstants;
-import com.oneops.api.util.JsonUtil;
 
-
+@Deprecated
 public class Cloud extends APIClient {
 
-	public Cloud(OOInstance instance) throws OneOpsClientAPIException {
-		super(instance);
-	}
-	
-	/**
-	 * Fetches specific cloud details
-	 * 
-	 * @param cloudName
-	 * @return
-	 * @throws OneOpsClientAPIException
-	 */
-	public CiResource getCloud(String cloudName) throws OneOpsClientAPIException {
-		if(cloudName == null || cloudName.length() == 0) {
-			String msg = "Missing cloud name to fetch details";
-			throw new OneOpsClientAPIException(msg);
-		}
-		
-		RequestSpecification request = createRequest();
-		Response response = request.get(IConstants.CLOUDS_URI + cloudName);
-		if(response != null) {
-			if(response.getStatusCode() == 200 || response.getStatusCode() == 302) {
-				return response.getBody().as(CiResource.class);
-			} else {
-				String msg = String.format("Failed to get cloud with name %s due to %s", cloudName, response.getStatusLine());
-				throw new OneOpsClientAPIException(msg);
-			}
-		} 
-		String msg = String.format("Failed to get cloud with name %s due to null response", cloudName);
-		throw new OneOpsClientAPIException(msg);
-	}
-	
-	/**
-	 * Lists all the clouds
-	 * 
-	 * @return
-	 * @throws OneOpsClientAPIException
-	 */
-	public List<CiResource> listClouds() throws OneOpsClientAPIException {
-		RequestSpecification request = createRequest();
-		Response response = request.get(IConstants.CLOUDS_URI);
-		if(response != null) {
-			if(response.getStatusCode() == 200 || response.getStatusCode() == 302) {
-				return JsonUtil.toObject(response.getBody().asString(), new TypeReference<List<CiResource>>(){});
-			} else {
-				String msg = String.format("Failed to get list of clouds due to %s", response.getStatusLine());
-				throw new OneOpsClientAPIException(msg);
-			}
-		} 
-		String msg = "Failed to get list of clouds due to null response";
-		throw new OneOpsClientAPIException(msg);
-	}
+  @Deprecated
+  public Cloud(OOInstance instance) throws OneOpsClientAPIException {
+    super(instance);
+  }
 
-	/**
-	 * Lists cloud variables given the cloudName
-	 *
-	 * @param cloudName
-	 * @return
-	 * @throws OneOpsClientAPIException
-	 */
-	public List<CiResource> listCloudVariables(String cloudName) throws OneOpsClientAPIException {
-		if(cloudName == null || cloudName.length() == 0) {
-			String msg = "Missing cloud name to list cloud variables";
-			throw new OneOpsClientAPIException(msg);
-		}
+  @Deprecated
+  public CiResource getCloud(String cloudName) throws OneOpsClientAPIException {
+    return super.getCloud(cloudName);
+  }
 
-		RequestSpecification request = createRequest();
-		Response response = request.get(IConstants.CLOUDS_URI + cloudName + IConstants.VARIABLES_URI );
-		if(response != null) {
-			if(response.getStatusCode() == 200 || response.getStatusCode() == 302) {
-				return JsonUtil.toObject(response.getBody().asString(), new TypeReference<List<CiResource>>(){});
-			} else {
-				String msg = String.format("Failed to get list of cloud variables due to %s", response.getStatusLine());
-				throw new OneOpsClientAPIException(msg);
-			}
-		}
-		String msg = "Failed to get list of cloud variables due to null response";
-		throw new OneOpsClientAPIException(msg);
-	}
+  @Deprecated
+  public List<CiResource> listClouds() throws OneOpsClientAPIException {
+    return super.listClouds();
+  }
+
+  public List<CiResource> listCloudVariables(String cloudName) throws OneOpsClientAPIException {
+    return super.listCloudVariables(cloudName);
+  }
 }

--- a/src/main/java/com/oneops/api/resource/Design.java
+++ b/src/main/java/com/oneops/api/resource/Design.java
@@ -1,1163 +1,157 @@
 package com.oneops.api.resource;
 
-import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Map.Entry;
 
-import org.json.JSONObject;
-
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.google.common.collect.Maps;
 import com.jayway.restassured.path.json.JsonPath;
-import com.jayway.restassured.response.Response;
-import com.jayway.restassured.specification.RequestSpecification;
 import com.oneops.api.APIClient;
 import com.oneops.api.OOInstance;
-import com.oneops.api.ResourceObject;
 import com.oneops.api.exception.OneOpsClientAPIException;
-import com.oneops.api.resource.model.AttrProps;
-import com.oneops.api.resource.model.CiAttributes;
 import com.oneops.api.resource.model.CiResource;
 import com.oneops.api.resource.model.Release;
-import com.oneops.api.util.IConstants;
-import com.oneops.api.util.JsonUtil;
 
-
+@Deprecated
 public class Design extends APIClient {
 
-	private String designReleaseURI;
-    private String designURI;
+  private final String assemblyName;
 
-    public Design(OOInstance instance, String assemblyName) throws OneOpsClientAPIException {
-		super(instance);
-		if(assemblyName == null || assemblyName.length() == 0) {
-			String msg = "Missing assembly name";
-			throw new OneOpsClientAPIException(msg);
-		}
-		designReleaseURI = IConstants.ASSEMBLY_URI + assemblyName + IConstants.DESIGN_URI + IConstants.RELEASES_URI;
-		designURI = IConstants.ASSEMBLY_URI + assemblyName + IConstants.DESIGN_URI;
-	}
-	
-	/**
-	 * Fetches specific platform details
-	 * 
-	 * @param platformName
-	 * @return
-	 * @throws OneOpsClientAPIException
-	 */
-	public CiResource getPlatform(String platformName) throws OneOpsClientAPIException {
-		if(platformName == null || platformName.length() == 0) {
-			String msg = "Missing platform name to fetch details";
-			throw new OneOpsClientAPIException(msg);
-		}
-		
-		RequestSpecification request = createRequest();
-		Response response = request.get(designURI + IConstants.PLATFORM_URI + platformName);
-		if(response != null) {
-			if(response.getStatusCode() == 200 || response.getStatusCode() == 302) {
-				return response.getBody().as(CiResource.class);
-			} else {
-				String msg = String.format("Failed to get platform with name %s due to %s", platformName, response.getStatusLine());
-				throw new OneOpsClientAPIException(msg);
-			}
-		} 
-		String msg = String.format("Failed to get platform with name %s due to null response", platformName);
-		throw new OneOpsClientAPIException(msg);
-	}
-	
-	/**
-	 * Lists all the platforms
-	 * 
-	 * @return
-	 * @throws OneOpsClientAPIException
-	 */
-	public List<CiResource> listPlatforms() throws OneOpsClientAPIException {
-		RequestSpecification request = createRequest();
-		Response response = request.get(designURI + IConstants.PLATFORM_URI);
-		if(response != null) {
-			if(response.getStatusCode() == 200 || response.getStatusCode() == 302) {
-				return JsonUtil.toObject(response.getBody().asString(), new TypeReference<List<CiResource>>(){});
-			} else {
-				String msg = String.format("Failed to get list of platforms due to %s", response.getStatusLine());
-				throw new OneOpsClientAPIException(msg);
-			}
-		} 
-		String msg = "Failed to get list of platforms due to null response";
-		throw new OneOpsClientAPIException(msg);
-	}
-	
+  public Design(OOInstance instance, String assemblyName) throws OneOpsClientAPIException {
+    super(instance);
+    if (assemblyName == null || assemblyName.length() == 0) {
+      String msg = "Missing assembly name";
+      throw new OneOpsClientAPIException(msg);
+    }
+    this.assemblyName = assemblyName;
+  }
 
-	/**
-	 * Creates platform within the given assembly
-	 * 
-	 * @param platformName {mandatory}
-	 * @param packname {mandatory}
-	 * @param packversion {mandatory}
-	 * @param packsource {mandatory}
-	 * @param comments
-	 * @param description
-	 * @return
-	 * @throws OneOpsClientAPIException
-	 */
-	public CiResource createPlatform(String platformName, String packname, String packversion, 
-			String packsource, String comments, String description) throws OneOpsClientAPIException {
-		
-		ResourceObject ro = new ResourceObject();
-		Map<String ,String> attributes = new HashMap<String ,String>();
-		Map<String ,String> properties= new HashMap<String ,String>();
-		
-		if(platformName != null && platformName.length() > 0) {
-			properties.put("ciName", platformName);
-		} else {
-			String msg = "Missing platform name to create platform";
-			throw new OneOpsClientAPIException(msg);
-		}
-		
-		if(packname != null && packname.length() > 0) {
-			attributes.put("pack", packname);
-		} else {
-			String msg = "Missing pack name to create platform";
-			throw new OneOpsClientAPIException(msg);
-		}
-		
-		if(packversion != null && packversion.length() > 0) {
-			attributes.put("version", packversion);
-		} else {
-			String msg = "Missing pack version to create platform";
-			throw new OneOpsClientAPIException(msg);
-		}
-		
-		if(packsource != null && packsource.length() > 0) {
-			attributes.put("source", packsource);
-		} else {
-			String msg = "Missing platform name to create platform";
-			throw new OneOpsClientAPIException(msg);
-		}
-		attributes.put("major_version", "1");
-		
-		properties.put("comments", comments);
-		ro.setProperties(properties);
-		
-		attributes.put("description", description);
-		ro.setAttributes(attributes);
-		
-		Map<String, String> ownerProps = Maps.newHashMap();
-		ownerProps.put("description", "");
-		ro.setOwnerProps(ownerProps );
-		RequestSpecification request = createRequest();
-		JSONObject jsonObject = JsonUtil.createJsonObject(ro , "cms_dj_ci");
-		Response response = request.body(jsonObject.toString()).post(designURI + IConstants.PLATFORM_URI);
-		
-		if(response != null) {
-			if(response.getStatusCode() == 200 || response.getStatusCode() == 302) {
-				return response.getBody().as(CiResource.class);
-			} else {
-				String msg = String.format("Failed to create platform with name %s due to %s", platformName, response.getStatusLine());
-				throw new OneOpsClientAPIException(msg);
-			}
-		} 
-		String msg = String.format("Failed to create platform with name %s due to null response", platformName);
-		throw new OneOpsClientAPIException(msg);
-	}
-	
-	
+  @Deprecated
+  public CiResource getPlatform(String platformName) throws OneOpsClientAPIException {
+    return super.getPlatform(assemblyName, platformName);
+  }
 
-	/**
-	 * Commits design open releases
-	 * 
-	 * @return
-	 * @throws OneOpsClientAPIException
-	 */
-	public Release commitDesign() throws OneOpsClientAPIException {
-		RequestSpecification request = createRequest();
-		Response response = request.get(designReleaseURI + "latest");
-		if(response != null) {
-			if(response.getStatusCode() == 200 || response.getStatusCode() == 302) {
-				
-				String releaseState = response.getBody().jsonPath().get("releaseState");
-				if("open".equals(releaseState)) {
-					int releaseId = response.getBody().jsonPath().get("releaseId");
-					response = request.post(designReleaseURI + releaseId + "/commit");
-					if(response.getStatusCode() == 200 || response.getStatusCode() == 302) {
-						return response.getBody().as(Release.class);
-					} else {
-						String msg = String.format("Failed to commit design due to %s",  response.getStatusLine());
-						throw new OneOpsClientAPIException(msg);
-					}
-				} else {
-					String msg = String.format("No open release found to perform design commit");
-					throw new OneOpsClientAPIException(msg);
-				}
-				
-			} else {
-				String msg = String.format("Failed to get latest release details due to %s",  response.getStatusLine());
-				throw new OneOpsClientAPIException(msg);
-			}
-		} 
-		String msg = "Failed to commit design due to null response";
-		throw new OneOpsClientAPIException(msg);
-	}
-	
-	
-	/**
-	 * Commits specific platform with open release
-	 * 
-	 * @return
-	 * @throws OneOpsClientAPIException
-	 */
-	public JsonPath commitPlatform(String platformName) throws OneOpsClientAPIException {
-		
-		RequestSpecification request = createRequest();
-		CiResource platform = getPlatform(platformName);
-		if(platform != null) {
-			Long platformId = platform.getCiId();
-			Response response = request.post(designURI + IConstants.PLATFORM_URI + platformId + "/commit");
-			if(response.getStatusCode() == 200 || response.getStatusCode() == 302) {
-				return response.getBody().jsonPath();
-			} else {
-				String msg = String.format("Failed to commit %s platform due to %s",  platformName, response.getStatusLine());
-				throw new OneOpsClientAPIException(msg);
-			}
-				
-		} 
-		String msg = String.format("Failed to commit %s due to null response", platformName);
-		throw new OneOpsClientAPIException(msg);
-	}
-	
-	public CiResource updatePlatformLinks(String fromPlatformName, List<String> toPlatformNames) throws OneOpsClientAPIException {
-		if(fromPlatformName == null || fromPlatformName.length() == 0) {
-			String msg = "Missing from platform name to link";
-			throw new OneOpsClientAPIException(msg);
-		}
-		if(toPlatformNames == null || toPlatformNames.size() == 0) {
-			String msg = "Missing to platform name to link";
-			throw new OneOpsClientAPIException(msg);
-		}
-		
-		List<Long> toIds = new ArrayList<Long>();
-		for(String toPlatformName :  toPlatformNames) {
-			CiResource toPlatform = getPlatform(toPlatformName);
-			toIds.add(toPlatform.getCiId());
-		}
-		
-		CiResource fromPlatform = getPlatform(fromPlatformName);
-		
-		ResourceObject ro = new ResourceObject();
-		Map<String ,String> properties= new HashMap<String ,String>();
-		properties.put("ciId", fromPlatform.getCiId() + "");
-		ro.setProperties(properties);
-		JSONObject jsonObject = JsonUtil.createJsonObject(ro , "cms_dj_ci");
-		jsonObject.put("links_to", toIds);
+  @Deprecated
+  public List<CiResource> listPlatforms() throws OneOpsClientAPIException {
+    return super.listPlatforms(assemblyName);
+  }
 
-		RequestSpecification request = createRequest();
-		Response response = request.body(jsonObject.toString()).put(designURI + IConstants.PLATFORM_URI + fromPlatform.getCiId());
-		
-		if(response != null) {
-			if(response.getStatusCode() == 200 || response.getStatusCode() == 302) {
-				return response.getBody().as(CiResource.class);
-			} else {
-				String msg = String.format("Failed to update platform link to %s from %s due to %s response", toPlatformNames, fromPlatformName, response.getStatusLine());
-				throw new OneOpsClientAPIException(msg);
-			}
-		} 
-		
-		String msg = String.format("Failed to update platform link to %s from %s due to null response", toPlatformNames, fromPlatformName);
-		throw new OneOpsClientAPIException(msg);
-	}
-	
-	/**
-	 * Deletes the given platform
-	 * 
-	 * @param platformName
-	 * @return
-	 * @throws OneOpsClientAPIException
-	 */
-	public CiResource deletePlatform(String platformName) throws OneOpsClientAPIException {
-		if(platformName == null || platformName.length() == 0) {
-			String msg = "Missing platform name to delete";
-			throw new OneOpsClientAPIException(msg);
-		}
-		
-		RequestSpecification request = createRequest();
-		Response response = request.delete(designURI + IConstants.PLATFORM_URI + platformName);
-		if(response != null) {
-			if(response.getStatusCode() == 200 || response.getStatusCode() == 302) {
-				return response.getBody().as(CiResource.class);
-			} else {
-				String msg = String.format("Failed to delete platform with name %s due to %s", platformName, response.getStatusLine());
-				throw new OneOpsClientAPIException(msg);
-			}
-		} 
-		String msg = String.format("Failed to delete platform with name %s due to null response", platformName);
-		throw new OneOpsClientAPIException(msg);
-	}
-	
-	/**
-	 * List platform components for a given assembly/design/platform
-	 * 
-	 * @param environmentName
-	 * @param platformName
-	 * @return
-	 * @throws OneOpsClientAPIException
-	 */
-	public List<CiResource> listPlatformComponents(String platformName) throws OneOpsClientAPIException {
-		if(platformName == null || platformName.length() == 0) {
-			String msg = "Missing platform name to list enviornment platform components";
-			throw new OneOpsClientAPIException(msg);
-		}
-		RequestSpecification request = createRequest();
-		Response response = request.get(designURI + IConstants.PLATFORM_URI + platformName + IConstants.COMPONENT_URI);
-		if(response != null) {
-			if(response.getStatusCode() == 200 || response.getStatusCode() == 302) {
-				return JsonUtil.toObject(response.getBody().asString(), new TypeReference<List<CiResource>>(){});
-			} else {
-				String msg = String.format("Failed to get list of platforms components due to %s", response.getStatusLine());
-				throw new OneOpsClientAPIException(msg);
-			}
-		} 
-		String msg = "Failed to get list of platforms components due to null response";
-		throw new OneOpsClientAPIException(msg);
-	}
-	
-	/**
-	 * Get platform component details for a given assembly/design/platform
-	 * 
-	 * @param platformName
-	 * @param componentName
-	 * @return
-	 * @throws OneOpsClientAPIException
-	 */
-	public CiResource getPlatformComponent(String platformName, String componentName) throws OneOpsClientAPIException {
-		if(platformName == null || platformName.length() == 0) {
-			String msg = "Missing platform name to get platform component details";
-			throw new OneOpsClientAPIException(msg);
-		}
-		if(componentName == null || componentName.length() == 0) {
-			String msg = "Missing component name to get platform component details";
-			throw new OneOpsClientAPIException(msg);
-		}
-		RequestSpecification request = createRequest();
-		Response response = request.get(designURI + IConstants.PLATFORM_URI + platformName + IConstants.COMPONENT_URI + componentName);
-		if(response != null) {
-			if(response.getStatusCode() == 200 || response.getStatusCode() == 302) {
-				return response.getBody().as(CiResource.class);
-			} else {
-				String msg = String.format("Failed to get platform component details due to %s", response.getStatusLine());
-				throw new OneOpsClientAPIException(msg);
-			}
-		} 
-		String msg = "Failed to get platform component details due to null response";
-		throw new OneOpsClientAPIException(msg);
-	}
-	
-	/**
-	 * Add component to a given assembly/design/platform
-	 * 
-	 * @param platformName
-	 * @param componentName
-	 * @param attributes
-	 * @return
-	 * @throws OneOpsClientAPIException
-	 */
-	public CiResource addPlatformComponent(String platformName, String componentName, String uniqueName, Map<String, String> attributes) throws OneOpsClientAPIException {
-		if(platformName == null || platformName.length() == 0) {
-			String msg = "Missing platform name to add component";
-			throw new OneOpsClientAPIException(msg);
-		}
-		if(componentName == null || componentName.length() == 0) {
-			String msg = "Missing component name to add component";
-			throw new OneOpsClientAPIException(msg);
-		}
+  @Deprecated
+  public CiResource createPlatform(String platformName, String packname, String packversion,
+    String packsource, String comments, String description) throws OneOpsClientAPIException {
+    return super.createPlatform(assemblyName, platformName, packname, packversion, packsource, comments, description);
+  }
 
-		RequestSpecification request = createRequest();
-		
-		Response newComponentResponse = request.queryParam("template_name", componentName).get(designURI + IConstants.PLATFORM_URI + platformName + IConstants.COMPONENT_URI + "new.json");
-		if(newComponentResponse != null) {
-			ResourceObject ro = new ResourceObject();
-			Map<String, String> properties = Maps.newHashMap();
-			properties.put("ciName", uniqueName);
-			properties.put("rfcAction", "add");
-			
-			JsonPath componentDetails = newComponentResponse.getBody().jsonPath();
-			Map<String, String> attr = componentDetails.getMap("ciAttributes");
-			if(attr == null) {
-				attr = Maps.newHashMap();
-			}
-			if(attributes != null && attributes.size() > 0) {
-				attr.putAll(attributes);
-				
-				Map<String, String> ownerProps =  componentDetails.getMap("ciAttrProps.owner");
-				if(ownerProps == null) {
-					ownerProps = Maps.newHashMap();
-				}
-				for(Entry<String, String> entry :  attributes.entrySet()) {
-					ownerProps.put(entry.getKey(), "design");
-				}
-				ro.setOwnerProps(ownerProps);
-			}
-			ro.setAttributes(attr);
-			ro.setProperties(properties);
-			JSONObject jsonObject = JsonUtil.createJsonObject(ro , "cms_dj_ci");
-			jsonObject.put("template_name", componentName);
-			Response response = request.body(jsonObject.toString()).post(designURI + IConstants.PLATFORM_URI + platformName + IConstants.COMPONENT_URI );
-			if(response != null) {
-				if(response.getStatusCode() == 200 || response.getStatusCode() == 302) {
-					return response.getBody().as(CiResource.class);
-				} else {
-					String msg = String.format("Failed to get add component %s due to %s", componentName, response.getStatusLine());
-					throw new OneOpsClientAPIException(msg);
-				}
-			} 
-		} 
-		
-		String msg = String.format("Failed to get add component %s due to null response", componentName);
-		throw new OneOpsClientAPIException(msg);
-	}
-	
-	/**
-	 * Update component attributes for a given assembly/design/platform/component
-	 * 
-	 * @param platformName
-	 * @param componentName
-	 * @param attributes
-	 * @return
-	 * @throws OneOpsClientAPIException
-	 */
-	public CiResource updatePlatformComponent(String platformName, String componentName, Map<String, String> attributes) throws OneOpsClientAPIException {
-		if(platformName == null || platformName.length() == 0) {
-			String msg = "Missing platform name to update component attributes";
-			throw new OneOpsClientAPIException(msg);
-		}
-		if(componentName == null || componentName.length() == 0) {
-			String msg = "Missing component name to update component attributes";
-			throw new OneOpsClientAPIException(msg);
-		}
-		if(attributes == null || attributes.size() == 0) {
-			String msg = "Missing attributes list to be updated";
-			throw new OneOpsClientAPIException(msg);
-		}
-		
-		CiResource componentDetails = getPlatformComponent(platformName, componentName);
-		if(componentDetails != null) {
-			ResourceObject ro = new ResourceObject();
-			
-			Long ciId = componentDetails.getCiId();
-			RequestSpecification request = createRequest();
-			
-			Map<String, String> attr = Maps.newHashMap();
-			//Add ciAttributes to be updated
-			if(attributes != null && attributes.size() > 0)
-				attr.putAll(attributes);
-			
-			Map<String, String> ownerProps = Maps.newHashMap();
-			//Add existing attrProps to retain locking of attributes 
-			AttrProps attrProps = componentDetails.getAttrProps();
-			if(attrProps != null && attrProps.getAdditionalProperties() != null && attrProps.getAdditionalProperties().size() > 0 && attrProps.getAdditionalProperties().get("owner") != null) {
-				Map<String, String> ownersMap = (Map<String, String>) attrProps.getAdditionalProperties().get("owner");
-				for(Entry<String, String> entry : ownersMap.entrySet()) {
-					ownerProps.put(entry.getKey(), entry.getValue());
-				}
-			}
-			
-			//Add updated attributes to attrProps to lock them
-			for(Entry<String, String> entry :  attributes.entrySet()) {
-				ownerProps.put(entry.getKey(), "design");
-			}
-			
-			ro.setOwnerProps(ownerProps);
-			ro.setAttributes(attr);
-			JSONObject jsonObject = JsonUtil.createJsonObject(ro , "cms_dj_ci");
- 			Response response = request.body(jsonObject.toString()).put(designURI + IConstants.PLATFORM_URI + platformName + IConstants.COMPONENT_URI + ciId);
-			if(response != null) {
-				if(response.getStatusCode() == 200 || response.getStatusCode() == 302) {
-					return response.getBody().as(CiResource.class);
-				} else {
-					String msg = String.format("Failed to get update component %s due to %s", componentName, response.getStatusLine());
-					throw new OneOpsClientAPIException(msg);
-				}
-			} 
-		}
-		String msg = String.format("Failed to get update component %s due to null response", componentName);
-		throw new OneOpsClientAPIException(msg);
-	}
-	
-	/**
-	 * Deletes the given platform component
-	 * 
-	 * @param platformName
-	 * @param componentName
-	 * @return
-	 * @throws OneOpsClientAPIException
-	 */
-	public CiResource deletePlatformComponent(String platformName, String componentName) throws OneOpsClientAPIException {
-		if(platformName == null || platformName.length() == 0) {
-			String msg = "Missing platform name to delete component";
-			throw new OneOpsClientAPIException(msg);
-		}
-		if(componentName == null || componentName.length() == 0) {
-			String msg = "Missing component name to delete it";
-			throw new OneOpsClientAPIException(msg);
-		}
-		
-		RequestSpecification request = createRequest();
-		Response response = request.delete(designURI + IConstants.PLATFORM_URI + platformName + IConstants.COMPONENT_URI + componentName);
-		if(response != null) {
-			if(response.getStatusCode() == 200 || response.getStatusCode() == 302) {
-				return response.getBody().as(CiResource.class);
-			} else {
-				String msg = String.format("Failed to delete platform with name %s due to %s", platformName, response.getStatusLine());
-				throw new OneOpsClientAPIException(msg);
-			}
-		} 
-		String msg = String.format("Failed to delete platform with name %s due to null response", platformName);
-		throw new OneOpsClientAPIException(msg);
-	}
-	
-	/**
-	 * List attachments for a given assembly/design/platform/component
-	 * 
-	 * @param platformName
-	 * @return
-	 * @throws OneOpsClientAPIException
-	 */
-	public List<CiResource> listPlatformComponentAttachments(String platformName, String componentName) throws OneOpsClientAPIException {
-		if(platformName == null || platformName.length() == 0) {
-			String msg = "Missing platform name to list platform attachments";
-			throw new OneOpsClientAPIException(msg);
-		}
-		RequestSpecification request = createRequest();
-		Response response = request.get(designURI + IConstants.PLATFORM_URI + platformName + IConstants.COMPONENT_URI + componentName + IConstants.ATTACHMENTS_URI);
-		if(response != null) {
-			if(response.getStatusCode() == 200 || response.getStatusCode() == 302) {
-				return JsonUtil.toObject(response.getBody().asString(), new TypeReference<List<CiResource>>(){});
-			} else {
-				String msg = String.format("Failed to get list of design platforms attachments due to %s", response.getStatusLine());
-				throw new OneOpsClientAPIException(msg);
-			}
-		} 
-		String msg = "Failed to get list of design platforms attachments due to null response";
-		throw new OneOpsClientAPIException(msg);
-	}
-	
-	/**
-	 * Get platform component attachment details 
-	 * 
-	 * @param platformName
-	 * @param componentName
-	 * @return
-	 * @throws OneOpsClientAPIException
-	 */
-	public CiResource getPlatformComponentAttachment(String platformName, String componentName, String attachmentName) throws OneOpsClientAPIException {
-		if(platformName == null || platformName.length() == 0) {
-			String msg = "Missing platform name to get platform component attachment details";
-			throw new OneOpsClientAPIException(msg);
-		}
-		if(componentName == null || componentName.length() == 0) {
-			String msg = "Missing component name to get platform component attachment details";
-			throw new OneOpsClientAPIException(msg);
-		}
-		RequestSpecification request = createRequest();
-		Response response = request.get(designURI + IConstants.PLATFORM_URI + platformName + IConstants.COMPONENT_URI + componentName + IConstants.ATTACHMENTS_URI + attachmentName);
-		if(response != null) {
-			if(response.getStatusCode() == 200 || response.getStatusCode() == 302) {
-				return response.getBody().as(CiResource.class);
-			} else {
-				String msg = String.format("Failed to get platform component attachment details due to %s", response.getStatusLine());
-				throw new OneOpsClientAPIException(msg);
-			}
-		} 
-		String msg = "Failed to get platform component attachment details due to null response";
-		throw new OneOpsClientAPIException(msg);
-	}
-	
-	/**
-	 * Update attachment
-	 * 
-	 * @param platformName
-	 * @param componentName
-	 * @param attachmentName
-	 * @param attributes
-	 * 
-	 *  Sample request for new attachment attributes
-	 * 	attributes.put("content", "content");
-		attributes.put("source", "source");
-		attributes.put("path", "/tmp/my.sh");
-		attributes.put("exec_cmd", "exec_cmd");
-		attributes.put("run_on", "after-add,after-replace,after-update");
-		attributes.put("run_on_action", "[\"after-restart\"]");
-		
-	 * @return
-	 * @throws OneOpsClientAPIException
-	 */
-	public CiResource updatePlatformComponentAttachment(String platformName, String componentName, String attachmentName, Map<String, String> attributes) throws OneOpsClientAPIException {
-		if(platformName == null || platformName.length() == 0) {
-			String msg = "Missing platform name to update attachment attributes";
-			throw new OneOpsClientAPIException(msg);
-		}
-		if(componentName == null || componentName.length() == 0) {
-			String msg = "Missing component name to update attachment attributes";
-			throw new OneOpsClientAPIException(msg);
-		}
-		if(attachmentName == null || attachmentName.length() == 0) {
-			String msg = "Missing attachment name to update attachment attributes";
-			throw new OneOpsClientAPIException(msg);
-		}
-		if(attributes == null || attributes.size() == 0) {
-			//nothing to be updated
-			return null;
-		}
-		
-		CiResource attachmentDetails = getPlatformComponentAttachment(platformName, componentName, attachmentName);
-		if(attachmentDetails != null) {
-			ResourceObject ro = new ResourceObject();
-			
-			Long ciId = attachmentDetails.getCiId();
-			RequestSpecification request = createRequest();
-			
-			//Add existing ciAttributes 
-			CiAttributes ciAttributes = attachmentDetails.getCiAttributes();
-			Map<String, String> attr = Maps.newHashMap();
-			if(ciAttributes != null && ciAttributes.getAdditionalProperties() != null && ciAttributes.getAdditionalProperties().size() > 0) {
-				for(Entry<String, Object> entry : ciAttributes.getAdditionalProperties().entrySet()) {
-					attr.put(entry.getKey(), String.valueOf(entry.getValue()));
-				}
-			}
-			
-			//Add ciAttributes to be updated
-			if(attributes != null && attributes.size() > 0)
-				attr.putAll(attributes);
-			
-			Map<String, String> ownerProps = Maps.newHashMap();
-			//Add existing attrProps to retain locking of attributes 
-			AttrProps attrProps = attachmentDetails.getAttrProps();
-			if(attrProps != null && attrProps.getAdditionalProperties() != null && attrProps.getAdditionalProperties().size() > 0 && attrProps.getAdditionalProperties().get("owner") != null) {
-				Map<String, String> ownersMap = (Map<String, String>) attrProps.getAdditionalProperties().get("owner");
-				for(Entry<String, String> entry : ownersMap.entrySet()) {
-					ownerProps.put(entry.getKey(), entry.getValue());
-				}
-			}
-			
-			//Add updated attributes to attrProps to lock them
-			for(Entry<String, String> entry :  attributes.entrySet()) {
-				ownerProps.put(entry.getKey(), "design");
-			}
-			
-			ro.setOwnerProps(ownerProps);
-			ro.setAttributes(attr);
-			JSONObject jsonObject = JsonUtil.createJsonObject(ro , "cms_dj_ci");
- 			Response response = request.body(jsonObject.toString()).put(designURI + IConstants.PLATFORM_URI + platformName 
- 					+ IConstants.COMPONENT_URI + componentName + IConstants.ATTACHMENTS_URI + ciId);
-			if(response != null) {
-				if(response.getStatusCode() == 200 || response.getStatusCode() == 302) {
-					return response.getBody().as(CiResource.class);
-				} else {
-					String msg = String.format("Failed to get update attachment %s due to %s", componentName, response.getStatusLine());
-					throw new OneOpsClientAPIException(msg);
-				}
-			} 
-		}
-		String msg = String.format("Failed to get update attachment %s due to null response", componentName);
-		throw new OneOpsClientAPIException(msg);
-	}
-	
-	/**
-	 * Add attachment to a given assembly/design/platform/component
-	 * 
-	 * @param platformName
-	 * @param componentName
-	 * @param attributes
-	 * 
-	 * Sample request for new attachment attributes
-	 * 	attributes.put("content", "content");
-		attributes.put("source", "source");
-		attributes.put("path", "/tmp/my.sh");
-		attributes.put("exec_cmd", "exec_cmd");
-		attributes.put("run_on", "after-add,after-replace,after-update");
-		attributes.put("run_on_action", "[\"after-restart\"]");
-	 * @return
-	 * @throws OneOpsClientAPIException
-	 */
-	public CiResource addNewAttachment(String platformName, String componentName, String uniqueName, Map<String, String> attributes) throws OneOpsClientAPIException {
-		if(platformName == null || platformName.length() == 0) {
-			String msg = "Missing platform name to add attachment";
-			throw new OneOpsClientAPIException(msg);
-		}
-		if(componentName == null || componentName.length() == 0) {
-			String msg = "Missing component name to add attachment";
-			throw new OneOpsClientAPIException(msg);
-		}
+  @Deprecated
+  public Release commitDesign() throws OneOpsClientAPIException {
+    return super.commitDesign(assemblyName);
+  }
 
-		RequestSpecification request = createRequest();
-		
-		Response newAttachmentResponse = request.get(designURI + IConstants.PLATFORM_URI + platformName + IConstants.COMPONENT_URI + componentName + IConstants.ATTACHMENTS_URI + "new.json");
-		if(newAttachmentResponse != null) {
-			ResourceObject ro = new ResourceObject();
-			Map<String, String> properties = Maps.newHashMap();
-			properties.put("ciName", uniqueName);
-			properties.put("rfcAction", "add");
-			
-			JsonPath attachmentDetails = newAttachmentResponse.getBody().jsonPath();
-			Map<String, String> attr = attachmentDetails.getMap("ciAttributes");
-			if(attr == null) {
-				attr = Maps.newHashMap();
-			}
-			if(attributes != null && attributes.size() > 0) {
-				attr.putAll(attributes);
-				
-				Map<String, String> ownerProps =  attachmentDetails.getMap("ciAttrProps.owner");
-				if(ownerProps == null) {
-					ownerProps = Maps.newHashMap();
-				}
-				for(Entry<String, String> entry :  attributes.entrySet()) {
-					ownerProps.put(entry.getKey(), "design");
-				}
-				ro.setOwnerProps(ownerProps);
-			}
-			ro.setAttributes(attr);
-			ro.setProperties(properties);
-			JSONObject jsonObject = JsonUtil.createJsonObject(ro , "cms_dj_ci");
-			Response response = request.body(jsonObject.toString()).post(designURI + IConstants.PLATFORM_URI + platformName + IConstants.COMPONENT_URI + componentName + IConstants.ATTACHMENTS_URI);
-			if(response != null) {
-				if(response.getStatusCode() == 200 || response.getStatusCode() == 302) {
-					return response.getBody().as(CiResource.class);
-				} else {
-					String msg = String.format("Failed to get add attachment to %s due to %s", componentName, response.getStatusLine());
-					throw new OneOpsClientAPIException(msg);
-				}
-			} 
-		} 
-		
-		String msg = String.format("Failed to get add attachment to %s due to null response", componentName);
-		throw new OneOpsClientAPIException(msg);
-	}
-	
-	/**
-	 * List local variables for a given assembly/design/platform
-	 * 
-	 * @param platformName
-	 * @return
-	 * @throws OneOpsClientAPIException
-	 */
-	public List<CiResource> listPlatformVariables(String platformName) throws OneOpsClientAPIException {
-		if(platformName == null || platformName.length() == 0) {
-			String msg = "Missing platform name to list platform variables";
-			throw new OneOpsClientAPIException(msg);
-		}
-		RequestSpecification request = createRequest();
-		Response response = request.get(designURI + IConstants.PLATFORM_URI + platformName + IConstants.VARIABLES_URI);
-		if(response != null) {
-			if(response.getStatusCode() == 200 || response.getStatusCode() == 302) {
-				return JsonUtil.toObject(response.getBody().asString(), new TypeReference<List<CiResource>>(){});
-			} else {
-				String msg = String.format("Failed to get list of design platforms variables due to %s", response.getStatusLine());
-				throw new OneOpsClientAPIException(msg);
-			}
-		} 
-		String msg = "Failed to get list of design platforms variables due to null response";
-		throw new OneOpsClientAPIException(msg);
-	}
-	
-	/**
-	 * Add platform variables for a given assembly/design
-	 * 
-	 * @param environmentName
-	 * @param variables
-	 * @return
-	 * @throws OneOpsClientAPIException
-	 */
-	public CiResource addPlatformVariable(String platformName, String variableName, String variableValue, boolean isSecure) throws OneOpsClientAPIException {
-		if(platformName == null || platformName.length() == 0) {
-			String msg = "Missing platform name to add variables";
-			throw new OneOpsClientAPIException(msg);
-		}
-		if(variableName == null ) {
-			String msg = "Missing variable name to be added";
-			throw new OneOpsClientAPIException(msg);
-		}
-		
-		if(variableValue == null ) {
-			String msg = "Missing variable value to be added";
-			throw new OneOpsClientAPIException(msg);
-		}
-		
-		RequestSpecification request = createRequest();
-			
-		Response variable = request.get(designURI + IConstants.PLATFORM_URI + platformName + IConstants.VARIABLES_URI + variableName);
-		if(variable != null && variable.getBody() != null && variable.getBody().jsonPath().getString("ciId") != null) {
-			String msg = String.format("Global variables %s already exists", variableName);
-			throw new OneOpsClientAPIException(msg);
-		}
-		ResourceObject ro = new ResourceObject();
-		Response newVarResponse = request.get(designURI + IConstants.PLATFORM_URI + platformName + IConstants.VARIABLES_URI + "new.json");
-		if(newVarResponse != null) {
-			JsonPath newVarJsonPath = newVarResponse.getBody().jsonPath();
-			if(newVarJsonPath != null) {
-				Map<String, String> attr = newVarJsonPath.getMap("ciAttributes");
-				Map<String, String> properties = Maps.newHashMap();
-				if(attr == null) {
-					attr = Maps.newHashMap();
-				}
-				if(isSecure) {
-					attr.put("secure", "true");
-					attr.put("encrypted_value", variableValue);
-				} else {
-					attr.put("secure", "false");
-					attr.put("value", variableValue);
-				}
-				
-				properties.put("ciName", variableName);
-				ro.setProperties(properties);
-				ro.setAttributes(attr);
-			}
-		}
-		
-		JSONObject jsonObject = JsonUtil.createJsonObject(ro , "cms_dj_ci");
-		
-		Response response = request.body(jsonObject.toString()).post(designURI + IConstants.PLATFORM_URI + platformName + IConstants.VARIABLES_URI );
-		if(response != null) {
-			if(response.getStatusCode() == 200 || response.getStatusCode() == 302) {
-				return response.getBody().as(CiResource.class);
-			} else {
-				String msg = String.format("Failed to add platform variable %s due to %s", variableName, response.getStatusLine());
-				throw new OneOpsClientAPIException(msg);
-			}
-		} 
-		
-		String msg = String.format("Failed to add new variables %s due to null response", variableName);
-		throw new OneOpsClientAPIException(msg);
-	}
-	
-	/**
-	 * Update platform local variables for a given assembly/design/platform
-	 * 
-	 * @param platformName
-	 * @param variables
-	 * @return
-	 * @throws OneOpsClientAPIException
-	 */
-	public Boolean updatePlatformVariable(String platformName, String variableName, String variableValue, boolean isSecure) throws OneOpsClientAPIException {
-		if(platformName == null || platformName.length() == 0) {
-			String msg = "Missing platform name to update variables";
-			throw new OneOpsClientAPIException(msg);
-		}
-		if(variableName == null ) {
-			String msg = "Missing variable name to be added";
-			throw new OneOpsClientAPIException(msg);
-		}
-		
-		if(variableValue == null ) {
-			String msg = "Missing variable value to be added";
-			throw new OneOpsClientAPIException(msg);
-		}
-		
-		Boolean success = false;
-		RequestSpecification request = createRequest();
-			
-		Response variable = request.get(designURI + IConstants.PLATFORM_URI + platformName + IConstants.VARIABLES_URI + variableName);
-		if(variable == null || variable.getStatusCode() != 200 || variable.getBody() == null) {
-			String msg = String.format("Failed to find local variables %s for platform %s", variableName, platformName);
-			throw new OneOpsClientAPIException(msg);
-		}
-		
-		JsonPath variableDetails = variable.getBody().jsonPath();
-		String ciId = variableDetails.getString("ciId");
-		Map<String, String> attr = variableDetails.getMap("ciAttributes");
-		if(attr == null) {
-			attr = new HashMap<String, String> ();
-		}
-		
-		if(isSecure) {
-			attr.put("secure", "true");
-			attr.put("encrypted_value", variableValue);
-		} else {
-			attr.put("secure", "false");
-			attr.put("value", variableValue);
-		}
-		
-		ResourceObject ro = new ResourceObject();
-		ro.setAttributes(attr);
-		
-		JSONObject jsonObject = JsonUtil.createJsonObject(ro , "cms_dj_ci");
-		
-		Response response = request.body(jsonObject.toString()).put(designURI + IConstants.PLATFORM_URI + platformName + IConstants.VARIABLES_URI + ciId);
-		if(response != null) {
-			if(response.getStatusCode() == 200 || response.getStatusCode() == 302) {
-				//return response.getBody().jsonPath();
-				success = true;
-			} else {
-				String msg = String.format("Failed to get update variables %s due to %s", variableName, response.getStatusLine());
-				throw new OneOpsClientAPIException(msg);
-			}
-		} 
-	
-		return success;
-	}
-	
-	/**
-	 * Update platform local variables for a given assembly/design/platform
-	 * 
-	 * @param platformName
-	 * @param variables
-	 * @return
-	 * @throws OneOpsClientAPIException
-	 */
-	public Boolean updateOrAddPlatformVariables(String platformName, String variableName, String variableValue, boolean isSecure) throws OneOpsClientAPIException {
-		if(platformName == null || platformName.length() == 0) {
-			String msg = "Missing platform name to update variables";
-			throw new OneOpsClientAPIException(msg);
-		}
-		if(variableName == null ) {
-			String msg = "Missing variable name to be added";
-			throw new OneOpsClientAPIException(msg);
-		}
-		
-		if(variableValue == null ) {
-			String msg = "Missing variable value to be added";
-			throw new OneOpsClientAPIException(msg);
-		}
-		
-		RequestSpecification request = createRequest();
-			
-		Response variable = request.get(designURI + IConstants.PLATFORM_URI + platformName + IConstants.VARIABLES_URI + variableName);
-		if(variable == null || variable.getStatusCode() != 200 || variable.getBody() == null) {
-			return addPlatformVariable(platformName, variableName, variableValue, isSecure) == null ? false : true;
-		} else {
-			return updatePlatformVariable(platformName, variableName, variableValue, isSecure) == null ? false : true;
-		}
-	}
-	
-	/**
-	 * Deletes the given platform variable
-	 * 
-	 * @param platformName
-	 * @param variableName
-	 * @return
-	 * @throws OneOpsClientAPIException
-	 */
-	
-	public CiResource deletePlatformVariable(String platformName, String variableName) throws OneOpsClientAPIException {
-		if(platformName == null || platformName.length() == 0) {
-			String msg = "Missing platform name to delete variable";
-			throw new OneOpsClientAPIException(msg);
-		}
-		if(variableName == null || variableName.length() == 0) {
-			String msg = "Missing variable name to delete it";
-			throw new OneOpsClientAPIException(msg);
-		}
-		
-		RequestSpecification request = createRequest();
-		Response response = request.delete(designURI + IConstants.PLATFORM_URI + platformName + IConstants.VARIABLES_URI + variableName);
-		if(response != null) {
-			if(response.getStatusCode() == 200 || response.getStatusCode() == 302) {
-				return response.getBody().as(CiResource.class);
-			} else {
-				String msg = String.format("Failed to delete platform with name %s due to %s", platformName, response.getStatusLine());
-				throw new OneOpsClientAPIException(msg);
-			}
-		} 
-		String msg = String.format("Failed to delete platform with name %s due to null response", platformName);
-		throw new OneOpsClientAPIException(msg);
-	}
+  @Deprecated
+  public JsonPath commitPlatform(String platformName) throws OneOpsClientAPIException {
+    return super.commitPlatform(assemblyName, platformName);
+  }
 
-	/**
-	 * List global variables for a given assembly/design
-	 * 
-	 * @return
-	 * @throws OneOpsClientAPIException
-	 */
-	public List<CiResource> listGlobalVariables() throws OneOpsClientAPIException {
-		RequestSpecification request = createRequest();
-		Response response = request.get(designURI + IConstants.VARIABLES_URI);
-		if(response != null) {
-			if(response.getStatusCode() == 200 || response.getStatusCode() == 302) {
-				return JsonUtil.toObject(response.getBody().asString(), new TypeReference<List<CiResource>>(){});
-			} else {
-				String msg = String.format("Failed to get list of design variables due to %s", response.getStatusLine());
-				throw new OneOpsClientAPIException(msg);
-			}
-		} 
-		String msg = "Failed to get list of design variables due to null response";
-		throw new OneOpsClientAPIException(msg);
-	}
-	
-	/**
-	 * Add global variables for a given assembly/design
-	 * 
-	 * @param environmentName
-	 * @param variables
-	 * @return
-	 * @throws OneOpsClientAPIException
-	 */
-	public CiResource addGlobalVariable(String variableName, String variableValue, boolean isSecure) throws OneOpsClientAPIException {
-		if(variableName == null ) {
-			String msg = "Missing variable name to be added";
-			throw new OneOpsClientAPIException(msg);
-		}
-		
-		if(variableValue == null ) {
-			String msg = "Missing variable value to be added";
-			throw new OneOpsClientAPIException(msg);
-		}
-		
-		RequestSpecification request = createRequest();
-			
-		Response variable = request.get(designURI + IConstants.VARIABLES_URI + variableName);
-		if(variable != null && variable.getBody() != null && variable.getBody().jsonPath().getString("ciId") != null) {
-			String msg = String.format("Global variables %s already exists", variableName);
-			throw new OneOpsClientAPIException(msg);
-		}
-		ResourceObject ro = new ResourceObject();
-		Response newVarResponse = request.get(designURI + IConstants.VARIABLES_URI + "new.json");
-		if(newVarResponse != null) {
-			JsonPath newVarJsonPath = newVarResponse.getBody().jsonPath();
-			if(newVarJsonPath != null) {
-				Map<String, String> attr = newVarJsonPath.getMap("ciAttributes");
-				Map<String, String> properties = Maps.newHashMap();
-				if(attr == null) {
-					attr = Maps.newHashMap();
-				}
-				if(isSecure) {
-					attr.put("secure", "true");
-					attr.put("encrypted_value", variableValue);
-				} else {
-					attr.put("secure", "false");
-					attr.put("value", variableValue);
-				}
+  @Deprecated
+  public CiResource updatePlatformLinks(String fromPlatformName, List<String> toPlatformNames) throws OneOpsClientAPIException {
+    return super.updatePlatformLinks(fromPlatformName, fromPlatformName, toPlatformNames);
+  }
 
-				properties.put("ciName", variableName);
-				ro.setProperties(properties);
-				ro.setAttributes(attr);
-			}
-		}
-		
-		JSONObject jsonObject = JsonUtil.createJsonObject(ro , "cms_dj_ci");
-		
-		Response response = request.body(jsonObject.toString()).post(designURI + IConstants.VARIABLES_URI );
-		if(response != null) {
-			if(response.getStatusCode() == 200 || response.getStatusCode() == 302) {
-				return response.getBody().as(CiResource.class);
-			} else {
-				String msg = String.format("Failed to get new global variable %s due to %s", variableName, response.getStatusLine());
-				throw new OneOpsClientAPIException(msg);
-			}
-		} 
-		
-		String msg = String.format("Failed to add new variables %s due to null response", variableName);
-		throw new OneOpsClientAPIException(msg);
-	}
-	
-	/**
-	 * Update global variables for a given assembly/design
-	 * 
-	 * @param environmentName
-	 * @param variables
-	 * @return
-	 * @throws OneOpsClientAPIException
-	 */
-	public Boolean updateGlobalVariable(String variableName, String variableValue, boolean isSecure) throws OneOpsClientAPIException {
-		if(variableName == null ) {
-			String msg = "Missing variable name to be added";
-			throw new OneOpsClientAPIException(msg);
-		}
-		
-		if(variableValue == null ) {
-			String msg = "Missing variable value to be added";
-			throw new OneOpsClientAPIException(msg);
-		}
-		
-		Boolean success = false;
-		RequestSpecification request = createRequest();
-			
-			Response variable = request.get(designURI + IConstants.VARIABLES_URI + variableName);
-			if(variable == null || variable.getBody() == null) {
-				String msg = String.format("Failed to find global variables %s", variableName);
-				throw new OneOpsClientAPIException(msg);
-			}
-			JsonPath variableDetails = variable.getBody().jsonPath();
-			String ciId = variableDetails.getString("ciId");
-			Map<String, String> attr = variableDetails.getMap("ciAttributes");
-			if(attr == null) {
-				attr = new HashMap<String, String> ();
-			}
-			if(isSecure) {
-				attr.put("secure", "true");
-				attr.put("encrypted_value", variableValue);
-			} else {
-				attr.put("secure", "false");
-				attr.put("value", variableValue);
-			}
-			
-			ResourceObject ro = new ResourceObject();
-			ro.setAttributes(attr);
-			
-			JSONObject jsonObject = JsonUtil.createJsonObject(ro , "cms_dj_ci");
-			
-			Response response = request.body(jsonObject.toString()).put(designURI + IConstants.VARIABLES_URI + ciId);
-			if(response != null) {
-				if(response.getStatusCode() == 200 || response.getStatusCode() == 302) {
-					success = true;
-				} else {
-					String msg = String.format("Failed to get update global variable %s due to %s", variableName, response.getStatusLine());
-					throw new OneOpsClientAPIException(msg);
-				}
-			} 
-		
-		return success;
-	}
-	
-	/**
-	 * Fetches specific platform details in Yaml format
-	 * 
-	 * @return
-	 * @throws OneOpsClientAPIException
-	 */
-	public JsonPath extractYaml() throws OneOpsClientAPIException {
-		RequestSpecification request = createRequest();
-		
-		Response response = request.get(designURI + "/extract.yaml");
-		if(response != null) {
-			if(response.getStatusCode() == 200 || response.getStatusCode() == 302) {
-				return response.getBody().jsonPath();
-			} else {
-				String msg = String.format("Failed to extract yaml content due to %s", response.getStatusLine());
-				throw new OneOpsClientAPIException(msg);
-			}
-		} 
-		String msg = "Failed to extract yaml content due to null response";
-		throw new OneOpsClientAPIException(msg);
-	}
-	
-	/**
-	 * Adds specific platform from Yaml/Json file input
-	 * 
-	 * @param platformName
-	 * @return
-	 * @throws OneOpsClientAPIException
-	 */
-	public JsonPath loadFile(String filecontent) throws OneOpsClientAPIException {
-		if(filecontent == null || filecontent.length() == 0) {
-			String msg = "Missing input file content";
-			throw new OneOpsClientAPIException(msg);
-		}
-		
-		RequestSpecification request = createRequest();
-		request.header("Content-Type", "multipart/text");
-		JSONObject jo = new JSONObject();
-		jo.put("data", filecontent);
-		
-		Response response = request.parameter("data", filecontent).put(designURI + "/load" );
-		if(response != null) {
-			if(response.getStatusCode() == 200 || response.getStatusCode() == 302) {
-				return response.getBody().jsonPath();
-			} else {
-				String msg = String.format("Failed to load yaml content due to %s", response.getStatusLine());
-				throw new OneOpsClientAPIException(msg);
-			}
-		} 
-		String msg = "Failed to load yaml content due to null response";
-		throw new OneOpsClientAPIException(msg);
-	}
-	
+  @Deprecated
+  public CiResource deletePlatform(String platformName) throws OneOpsClientAPIException {
+    return super.deletePlatform(platformName, platformName);
+  }
+
+  @Deprecated
+  public List<CiResource> listPlatformComponents(String platformName) throws OneOpsClientAPIException {
+    return super.listPlatformComponents(platformName, platformName);
+  }
+
+  @Deprecated
+  public CiResource getPlatformComponent(String platformName, String componentName) throws OneOpsClientAPIException {
+    return super.getPlatformComponent(componentName, platformName, componentName);
+  }
+
+  @Deprecated
+  public CiResource addPlatformComponent(String platformName, String componentName, String uniqueName, Map<String, String> attributes) throws OneOpsClientAPIException {
+    return super.addPlatformComponent(uniqueName, platformName, componentName, uniqueName, attributes);
+  }
+
+  @Deprecated
+  public CiResource updatePlatformComponent(String platformName, String componentName, Map<String, String> attributes) throws OneOpsClientAPIException {
+    return super.updatePlatformComponent(assemblyName, platformName, componentName, attributes);
+  }
+
+  @Deprecated
+  public CiResource deletePlatformComponent(String platformName, String componentName) throws OneOpsClientAPIException {
+    return super.deletePlatformComponent(assemblyName, platformName, componentName);
+  }
+
+  @Deprecated
+  public List<CiResource> listPlatformComponentAttachments(String platformName, String componentName) throws OneOpsClientAPIException {
+    return super.listPlatformComponentAttachments(assemblyName, platformName, componentName);
+  }
+
+  @Deprecated
+  public CiResource getPlatformComponentAttachment(String platformName, String componentName, String attachmentName) throws OneOpsClientAPIException {
+    return super.getPlatformComponentAttachment(assemblyName, platformName, componentName, attachmentName);
+  }
+
+  @Deprecated
+  public CiResource updatePlatformComponentAttachment(String platformName, String componentName, String attachmentName, Map<String, String> attributes) throws OneOpsClientAPIException {
+    return super.updatePlatformComponentAttachment(assemblyName, platformName, componentName, attachmentName, attributes);
+  }
+
+  @Deprecated
+  public CiResource addNewAttachment(String platformName, String componentName, String uniqueName, Map<String, String> attributes) throws OneOpsClientAPIException {
+    return super.addNewAttachment(assemblyName, platformName, componentName, uniqueName, attributes);
+  }
+
+  @Deprecated
+  public List<CiResource> listPlatformVariables(String platformName) throws OneOpsClientAPIException {
+    return super.listPlatformVariables(assemblyName, platformName);
+  }
+
+  @Deprecated
+  public CiResource addPlatformVariable(String platformName, String variableName, String variableValue, boolean isSecure) throws OneOpsClientAPIException {
+    return super.addPlatformVariable(assemblyName, platformName, variableName, variableValue, isSecure);
+  }
+
+  @Deprecated
+  public Boolean updatePlatformVariable(String platformName, String variableName, String variableValue, boolean isSecure) throws OneOpsClientAPIException {
+    return super.updatePlatformVariable(assemblyName, platformName, variableName, variableValue, isSecure);
+  }
+
+  @Deprecated
+  public Boolean updateOrAddPlatformVariables(String platformName, String variableName, String variableValue, boolean isSecure) throws OneOpsClientAPIException {
+    return super.updateOrAddPlatformVariables(assemblyName, platformName, variableName, variableValue, isSecure);
+  }
+
+  @Deprecated
+  public CiResource deletePlatformVariable(String platformName, String variableName) throws OneOpsClientAPIException {
+    return super.deletePlatformVariable(assemblyName, platformName, variableName);
+  }
+
+  @Deprecated
+  public List<CiResource> listGlobalVariables() throws OneOpsClientAPIException {
+    return super.listGlobalVariables(assemblyName);
+  }
+
+  @Deprecated
+  public CiResource addGlobalVariable(String variableName, String variableValue, boolean isSecure) throws OneOpsClientAPIException {
+    return super.addGlobalVariable(assemblyName, variableName, variableValue, isSecure);
+  }
+
+  @Deprecated
+  public Boolean updateGlobalVariable(String variableName, String variableValue, boolean isSecure) throws OneOpsClientAPIException {
+    return super.updateGlobalVariable(assemblyName, variableName, variableValue, isSecure);
+  }
+
+  @Deprecated
+  public JsonPath extractYaml() throws OneOpsClientAPIException {
+    return super.extractYaml(assemblyName);
+  }
+
+  @Deprecated
+  public JsonPath loadFile(String filecontent) throws OneOpsClientAPIException {
+    return super.loadFile(assemblyName, filecontent);
+  }
 }

--- a/src/main/java/com/oneops/api/resource/Monitor.java
+++ b/src/main/java/com/oneops/api/resource/Monitor.java
@@ -1,188 +1,70 @@
 package com.oneops.api.resource;
 
-import java.util.HashMap;
-import java.util.Map;
-
 import org.json.JSONObject;
 
-import com.jayway.restassured.response.Response;
-import com.jayway.restassured.specification.RequestSpecification;
 import com.oneops.api.APIClient;
 import com.oneops.api.OOInstance;
-import com.oneops.api.ResourceObject;
 import com.oneops.api.exception.OneOpsClientAPIException;
 import com.oneops.api.resource.model.CiResource;
-import com.oneops.api.util.IConstants;
-import com.oneops.api.util.JsonUtil;
 
+@Deprecated
 public class Monitor extends APIClient {
 
-	private String transitionMonitorUri;
-	private String environmentName;
-	
-	public Monitor(OOInstance instance, String assemblyName, String environment, String platform, String component) throws OneOpsClientAPIException {
-		super(instance);
-		if(assemblyName == null || assemblyName.length() == 0) {
-			String msg = "Missing assembly name";
-			throw new OneOpsClientAPIException(msg);
-		}
-		if(environment == null || environment.length() == 0) {
-			String msg = "Missing environment name";
-			throw new OneOpsClientAPIException(msg);
-		}
-		if(platform == null || platform.length() == 0) {
-			String msg = "Missing platform name";
-			throw new OneOpsClientAPIException(msg);
-		}
-		if(component == null || component.length() == 0) {
-			String msg = "Missing component name";
-			throw new OneOpsClientAPIException(msg);
-		}
-		
-		this.environmentName = environment;
-		transitionMonitorUri = IConstants.ASSEMBLY_URI + assemblyName + IConstants.TRANSITION_URI +  IConstants.ENVIRONMENT_URI
-				 + environmentName 
-				+ IConstants.PLATFORM_URI + platform
-				+ IConstants.COMPONENT_URI + component + IConstants.MONITORS_URI;
-	}
-	
-	/**
-	 * Fetches specific monitor details
-	 * 
-	 * @param monitorName
-	 * @return
-	 * @throws OneOpsClientAPIException
-	 */
-	public CiResource getMonitor(String monitorName) throws OneOpsClientAPIException {
-		if(monitorName == null || monitorName.length() == 0) {
-			String msg = "Missing monitor name to fetch details";
-			throw new OneOpsClientAPIException(msg);
-		}
-		
-		RequestSpecification request = createRequest();
-		Response response = request.get(transitionMonitorUri + monitorName);
-		if(response != null) {
-			if(response.getStatusCode() == 200 || response.getStatusCode() == 302) {
-				return response.getBody().as(CiResource.class);
-			} else {
-				String msg = String.format("Failed to get environment with name %s due to %s", environmentName, response.getStatusLine());
-				throw new OneOpsClientAPIException(msg);
-			}
-		} 
-		String msg = String.format("Failed to get environment with name %s due to null response", environmentName);
-		throw new OneOpsClientAPIException(msg);
-	}
-	
-	
-	
-	/**
-	 * Update monitor
-	 * 
-	 * @param monitorName
-	 * @param cmdOptions
-	 * @param duration
-	 * @param sampleInterval
-	 * @param thresholds
-	 * @param heartbeat
-	 * @param enable
-	 * @return
-	 * @throws OneOpsClientAPIException
-	 */
-	public CiResource updateMonitor(String monitorName, String cmdOptions, Integer duration, Integer sampleInterval, JSONObject thresholds, boolean heartbeat, boolean enable) throws OneOpsClientAPIException {
-		if(monitorName == null || monitorName.length() == 0) {
-			String msg = "Missing monitor name to fetch details";
-			throw new OneOpsClientAPIException(msg);
-		}
-		
-		RequestSpecification request = createRequest();
-		Response response = request.get(transitionMonitorUri + monitorName);
-		
-		ResourceObject ro = new ResourceObject();
-		Map<String, String> attributes = new HashMap<String ,String>();
-		JSONObject monitor = JsonUtil.createJsonObject(response.getBody().asString());
-		if(monitor != null && monitor.has("ciAttributes")) {
-			JSONObject attrs = monitor.getJSONObject("ciAttributes");
-			 for (Object key : attrs.keySet()) {
-		        //based on you key types
-		        String keyStr = (String)key;
-		        String keyvalue = String.valueOf(attrs.get(keyStr));
+  private String assemblyName;
+  private String environmentName;
+  private String platform;
+  private String component;
 
-		        attributes.put(keyStr, keyvalue);
-		        
-		        if(cmdOptions != null && attributes.containsKey("cmd_options")) {
-					attributes.put("cmd_options", String.valueOf(cmdOptions));
-				}
-				
-				if(duration != null && attributes.containsKey("duration")) {
-					attributes.put("duration", String.valueOf(duration));
-				}
-				
-				if(sampleInterval != null && attributes.containsKey("sample_interval")) {
-					attributes.put("sample_interval", String.valueOf(sampleInterval));
-				}
-				
-				if(thresholds != null && attributes.containsKey("thresholds")) {
-					attributes.put("thresholds", thresholds.toString());
-				}
-				
-		    }
-			attributes.put("heartbeat", String.valueOf(heartbeat));
-			attributes.put("enable", String.valueOf(enable));
-		}
-		ro.setAttributes(attributes);
-		JSONObject jsonObject = JsonUtil.createJsonObject(ro , "cms_dj_ci");
-		response = request.body(jsonObject.toString()).put(transitionMonitorUri + monitorName);
-		if(response != null) {
-			if(response.getStatusCode() == 200 || response.getStatusCode() == 302) {
-				return response.getBody().as(CiResource.class);
-			} else {
-				String msg = String.format("Failed to monitor definition for monitor %s due to %s", monitorName, response.getStatusLine());
-				throw new OneOpsClientAPIException(msg);
-			}
-		}		
-		
-		String msg = String.format("Failed to update monitor definition for %s due to null response", monitorName);
-		throw new OneOpsClientAPIException(msg);
-	}
-	
-	
-	public JSONObject getThresholdJson(String name, String state, String metric, String bucket, String stat, JSONObject trigger, JSONObject reset) {
-		JSONObject thresholdDef = new JSONObject();
-		thresholdDef.put("bucket", bucket);
-		thresholdDef.put("metric", metric);
-		thresholdDef.put("state", state);
-		thresholdDef.put("stat", stat);
-		thresholdDef.put("trigger", trigger);
-		thresholdDef.put("reset", reset);
-		
-		JSONObject threshold = new JSONObject();
-		threshold.put(name, thresholdDef);
-		
-		return threshold;
-	}
-	
-	public JSONObject createThresholdCondition(String operator, int value, int duration, int numOfOccurances) {
-		JSONObject thresholdCondition = new JSONObject();
-		thresholdCondition.put("operator", operator);
-		thresholdCondition.put("value", value);
-		thresholdCondition.put("duration", duration);
-		thresholdCondition.put("numocc", numOfOccurances);
-		
-		return thresholdCondition;
-	}
-	
-	public JSONObject addMetrics(String metricName, String unit, String dstype, String display, String description){
-		JSONObject metricinfo = new JSONObject();
-		metricinfo.put("unit", unit);
-		metricinfo.put("dstype", dstype);
-		metricinfo.put("display", display);
-		metricinfo.put("display_group", "");
-		metricinfo.put("description", description);
-		return metricinfo;
-	}
-	
-	//list thresholds
-	//add threshold
-	//update threshold
-	//delete threshold
+  public Monitor(OOInstance instance, String assemblyName, String environment, String platform, String component) throws OneOpsClientAPIException {
+    super(instance);
+    if (assemblyName == null || assemblyName.length() == 0) {
+      String msg = "Missing assembly name";
+      throw new OneOpsClientAPIException(msg);
+    }
+    if (environment == null || environment.length() == 0) {
+      String msg = "Missing environment name";
+      throw new OneOpsClientAPIException(msg);
+    }
+    if (platform == null || platform.length() == 0) {
+      String msg = "Missing platform name";
+      throw new OneOpsClientAPIException(msg);
+    }
+    if (component == null || component.length() == 0) {
+      String msg = "Missing component name";
+      throw new OneOpsClientAPIException(msg);
+    }
+
+    this.environmentName = environment;
+  }
+
+  @Deprecated
+  public CiResource getMonitor(String monitorName) throws OneOpsClientAPIException {
+    return super.getMonitor(assemblyName, platform, component, environmentName, monitorName);
+  }
+
+  @Deprecated
+  public CiResource updateMonitor(String monitorName, String cmdOptions, Integer duration, Integer sampleInterval, JSONObject thresholds, boolean heartbeat, boolean enable)
+    throws OneOpsClientAPIException {
+    return super.updateMonitor(assemblyName, platform, component, environmentName, monitorName, cmdOptions, duration, sampleInterval, thresholds, heartbeat, enable);
+  }
+
+  @Deprecated
+  public JSONObject getThresholdJson(String name, String state, String metric, String bucket, String stat, JSONObject trigger, JSONObject reset) {
+    return super.getThresholdJson(name, state, metric, bucket, stat, trigger, reset);
+  }
+
+  @Deprecated
+  public JSONObject createThresholdCondition(String operator, int value, int duration, int numOfOccurances) {
+    return super.createThresholdCondition(operator, value, duration, numOfOccurances);
+  }
+
+  @Deprecated
+  public JSONObject addMetrics(String metricName, String unit, String dstype, String display, String description) {
+    return super.addMetrics(metricName, unit, dstype, display, description);
+  }
+
+  //list thresholds
+  //add threshold
+  //update threshold
+  //delete threshold
 }

--- a/src/main/java/com/oneops/api/resource/Operation.java
+++ b/src/main/java/com/oneops/api/resource/Operation.java
@@ -1,506 +1,96 @@
 package com.oneops.api.resource;
 
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
-import org.json.JSONObject;
-
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.google.common.collect.Lists;
-import com.google.common.collect.Maps;
 import com.jayway.restassured.path.json.JsonPath;
-import com.jayway.restassured.response.Response;
-import com.jayway.restassured.specification.RequestSpecification;
 import com.oneops.api.APIClient;
 import com.oneops.api.OOInstance;
-import com.oneops.api.ResourceObject;
 import com.oneops.api.exception.OneOpsClientAPIException;
 import com.oneops.api.resource.model.CiResource;
 import com.oneops.api.resource.model.Procedure;
-import com.oneops.api.util.IConstants;
-import com.oneops.api.util.JsonUtil;
 
+@Deprecated
 public class Operation extends APIClient {
-	
-	private String operationURI;
-	private OOInstance instance;
-	private String assemblyName;
-	private String environmentName;
-	
-	public Operation(OOInstance instance, String assemblyName, String environmentName) throws OneOpsClientAPIException {
-		super(instance);
-		if(assemblyName == null || assemblyName.length() == 0) {
-			String msg = "Missing assembly name";
-			throw new OneOpsClientAPIException(msg);
-		}
-		
-		if(environmentName == null || environmentName.length() == 0) {
-			String msg = "Missing environment name";
-			throw new OneOpsClientAPIException(msg);
-		}
-		
-		this.assemblyName = assemblyName;
-		this.environmentName = environmentName;
-		this.instance = instance;
-		operationURI = IConstants.ASSEMBLY_URI + assemblyName + IConstants.OPERATION_URI  + IConstants.ENVIRONMENT_URI + environmentName;
-	}
 
-	/**
-	 * Lists all instances for a given assembly, environment, platform and component
-	 * 
-	 * @return
-	 * @throws OneOpsClientAPIException
-	 */
-	public List<CiResource> listInstances(String platformName, String componentName) throws OneOpsClientAPIException {
-		if(platformName == null || platformName.length() == 0) {
-			String msg = "Missing platform name to fetch details";
-			throw new OneOpsClientAPIException(msg);
-		}
-		if(componentName == null || componentName.length() == 0) {
-			String msg = "Missing component name to fetch details";
-			throw new OneOpsClientAPIException(msg);
-		}
-		
-		RequestSpecification request = createRequest();
-		Response response = request.queryParam("instances_state", "all").get(operationURI 
-				+ IConstants.PLATFORM_URI + platformName 
-				+ IConstants.COMPONENT_URI + componentName 
-				+ IConstants.INSTANCES_URI);
-		if(response != null) {
-			if(response.getStatusCode() == 200 || response.getStatusCode() == 302) {
-				return JsonUtil.toObject(response.getBody().asString(), new TypeReference<List<CiResource>>(){});
-				} else {
-				String msg = String.format("Failed to get instances due to %s", response.getStatusLine());
-				throw new OneOpsClientAPIException(msg);
-			}
-		} 
-		String msg = "Failed to get instances due to null response";
-		throw new OneOpsClientAPIException(msg);
-	}
+  private String assemblyName;
+  private String environmentName;
 
-	
-	/**
-	 * Mark all instances for replacement for a given platform and component
-	 * 
-	 * @return
-	 * @throws OneOpsClientAPIException
-	 */
-	public Boolean markInstancesForReplacement(String platformName, String componentName) throws OneOpsClientAPIException {
-		List<CiResource> instances = listInstances(platformName, componentName);
-		List<Long> instanceIds = Lists.newArrayList();
-		for (CiResource ciResource : instances) {
-			instanceIds.add(ciResource.getCiId());
-		}
-		return markInstancesForReplacement(platformName, componentName, instanceIds);
-	}
-	
-	/**
-	 * Mark an instance for replacement for a given platform and component
-	 * 
-	 * @return
-	 * @throws OneOpsClientAPIException
-	 */
-	public Boolean markInstanceForReplacement(String platformName, String componentName, Long instanceId) throws OneOpsClientAPIException {
-		List<Long> instanceIds = Lists.newArrayList();
-		instanceIds.add(instanceId);
-		return markInstancesForReplacement(platformName, componentName, instanceIds);
-	}
-	
-	/**
-	 * Mark an instance for replacement for a given platform and component
-	 * 
-	 * @return
-	 * @throws OneOpsClientAPIException
-	 */
-	Boolean markInstancesForReplacement(String platformName, String componentName, List<Long> instanceIds) throws OneOpsClientAPIException {
-		RequestSpecification request = createRequest();
-		JSONObject jo = new JSONObject();
-		jo.put("ids", instanceIds);
-		jo.put("state", "replace");
-		String uri = IConstants.ASSEMBLY_URI + assemblyName + IConstants.OPERATION_URI +  IConstants.INSTANCES_URI + "state" ;
-		
-		Response response = request.body(jo.toString()).put(uri);
-		if(response != null) {
-			if(response.getStatusCode() == 200 || response.getStatusCode() == 302) {
-				return response.getBody().as(Boolean.class);
-			} else {
-				String msg = String.format("Failed to set replace marker on instance(s) due to %s", response.getStatusLine());
-				throw new OneOpsClientAPIException(msg);
-			}
-		} 
-		String msg = "Failed to set replace marker on instance(s) due to null response";
-		throw new OneOpsClientAPIException(msg);
-	}
-	
-	public JsonPath getLogData(String procedureId, List<String> actionIds) throws OneOpsClientAPIException {
-		RequestSpecification request = createRequest();
-		String uri = IConstants.OPERATION_URI + IConstants.PROCEDURES_URI + "log_data" ;
-		request.queryParam("procedure_id", procedureId);
-		
-		if(actionIds != null) {
-			for(String actionId : actionIds){
-				request.queryParam("action_ids", actionId);
-			}
-		}
-		
-		Response response = request.get(uri);
-		if(response != null) {
-			if(response.getStatusCode() == 200 || response.getStatusCode() == 302) {
-				return response.getBody().jsonPath();
-			} else {
-				String msg = String.format("Failed to set replace marker on instance(s) due to %s", response.getStatusLine());
-				throw new OneOpsClientAPIException(msg);
-			}
-		} 
-		String msg = "Failed to set replace marker on instance(s) due to null response";
-		throw new OneOpsClientAPIException(msg);
-	}
-	
-	/**
-	 * Lists all procedures for a given platform 
-	 * 
-	 * @return
-	 * @throws OneOpsClientAPIException
-	 */
-	public List<CiResource> listProcedures(String platformName) throws OneOpsClientAPIException {
-		if(platformName == null || platformName.length() == 0) {
-			String msg = "Missing platform name to fetch details";
-			throw new OneOpsClientAPIException(msg);
-		}
-		RequestSpecification request = createRequest();
-		Response response = request.get(operationURI 
-				+ IConstants.PLATFORM_URI + platformName 
-				+ IConstants.PROCEDURES_URI);
-		if(response != null) {
-			if(response.getStatusCode() == 200 || response.getStatusCode() == 302) {
-				return JsonUtil.toObject(response.getBody().asString(), new TypeReference<List<CiResource>>(){});
-				} else {
-				String msg = String.format("Failed to get procedures due to %s", response.getStatusLine());
-				throw new OneOpsClientAPIException(msg);
-			}
-		} 
-		String msg = "Failed to get procedures due to null response";
-		throw new OneOpsClientAPIException(msg);
-	}
-	
-	
-	/**
-	 * Get procedure Id for a given platform, procedure name 
-	 * 
-	 * @return
-	 * @throws OneOpsClientAPIException
-	 */
-	public Long getProcedureId(String platformName, String procedureName) throws OneOpsClientAPIException {
-		if(platformName == null || platformName.length() == 0) {
-			String msg = "Missing platform name to fetch details";
-			throw new OneOpsClientAPIException(msg);
-		}
-		if(procedureName == null || procedureName.length() == 0) {
-			String msg = "Missing procedure name to fetch details";
-			throw new OneOpsClientAPIException(msg);
-		}
-		
-		List<CiResource> procs = listProcedures(platformName);
-		if(procs != null) {
-			for (CiResource procedure : procs) {
-				if(procedureName.equals(procedure.getCiName())) {
-					return procedure.getCiId();
-				}
-			}
-		}
-		
-		String msg = String.format("Failed to get procedure with the given name %s ", procedureName);
-		throw new OneOpsClientAPIException(msg);
-	}
-	
-	/**
-	 * Lists all actions for a given platform, component
-	 * 
-	 * @return
-	 * @throws OneOpsClientAPIException
-	 */
-	public JsonPath listActions(String platformName, String componentName) throws OneOpsClientAPIException {
-		if(platformName == null || platformName.length() == 0) {
-			String msg = "Missing platform name to fetch details";
-			throw new OneOpsClientAPIException(msg);
-		}
-		if(componentName == null || componentName.length() == 0) {
-			String msg = "Missing component name to fetch details";
-			throw new OneOpsClientAPIException(msg);
-		}
-		
-		RequestSpecification request = createRequest();
-		Response response = request.get(operationURI 
-				+ IConstants.PLATFORM_URI + platformName 
-				+ IConstants.COMPONENT_URI + componentName
-				+ IConstants.ACTIONS_URI);
-		if(response != null) {
-			if(response.getStatusCode() == 200 || response.getStatusCode() == 302) {
-				return response.getBody().jsonPath();
-			} else {
-				String msg = String.format("Failed to get actions due to %s", response.getStatusLine());
-				throw new OneOpsClientAPIException(msg);
-			}
-		} 
-		String msg = "Failed to get actions due to null response";
-		throw new OneOpsClientAPIException(msg);
-	}
-	
-	
-	/**
-	 * Execute procedure for a given platform
-	 * 
-	 * @return
-	 * @throws OneOpsClientAPIException
-	 */
-	public Procedure executeProcedure(String platformName, String procedureName, String arglist) throws OneOpsClientAPIException {
-		if(platformName == null || platformName.length() == 0) {
-			String msg = "Missing platform name to fetch details";
-			throw new OneOpsClientAPIException(msg);
-		}
-		if(procedureName == null || procedureName.length() == 0) {
-			String msg = "Missing procedure name to fetch details";
-			throw new OneOpsClientAPIException(msg);
-		}
-		
-		RequestSpecification request = createRequest();
-		ResourceObject ro = new ResourceObject();
-		Map<String ,String> properties= new HashMap<String ,String>();
-		
-		Transition transition = new Transition(instance, this.assemblyName);
-		CiResource platform = transition.getPlatform(this.environmentName, platformName);
-		Long platformId = platform.getCiId();
-		properties.put("procedureState", "active");
-		properties.put("arglist", arglist);
-		properties.put("definition",null);
-		properties.put("ciId", "" +  platformId);
-		properties.put("procedureCiId", "" + getProcedureId(platformName, procedureName));
-		ro.setProperties(properties);
-		
-		JSONObject jsonObject = JsonUtil.createJsonObject(ro , "cms_procedure");
-		Response response = request.body(jsonObject.toString()).post(IConstants.OPERATION_URI +  IConstants.PROCEDURES_URI);
-		if(response != null) {
-			if(response.getStatusCode() == 200 || response.getStatusCode() == 302) {
-				return response.getBody().as(Procedure.class);
-			} else {
-				String msg = String.format("Failed to execute procedures due to %s", response.getStatusLine());
-				throw new OneOpsClientAPIException(msg);
-			}
-		} 
-		String msg = "Failed to execute procedures due to null response";
-		throw new OneOpsClientAPIException(msg);
-	}
-	
-	/**
-	 * Get procedure status for a given Id 
-	 * 
-	 * @return
-	 * @throws OneOpsClientAPIException
-	 */
-	public Procedure getProcedureStatus(Long procedureId) throws OneOpsClientAPIException {
-		if(procedureId == null) {
-			String msg = "Missing procedure Id to fetch details";
-			throw new OneOpsClientAPIException(msg);
-		}
-		
-		RequestSpecification request = createRequest();
-		Response response = request.get(IConstants.OPERATION_URI +  IConstants.PROCEDURES_URI + procedureId);
-		if(response != null) {
-			if(response.getStatusCode() == 200 || response.getStatusCode() == 302) {
-				return response.getBody().as(Procedure.class);
-			} else {
-				String msg = String.format("Failed to get procedure status due to %s", response.getStatusLine());
-				throw new OneOpsClientAPIException(msg);
-			}
-		} 
-		
-		String msg = String.format("Failed to get procedure status with the given Id " + procedureId);
-		throw new OneOpsClientAPIException(msg);
-	}
-	
-	/**
-	 * Get procedure status for a given Id 
-	 * 
-	 * @return
-	 * @throws OneOpsClientAPIException
-	 */
-	public Procedure cancelProcedure(Long procedureId) throws OneOpsClientAPIException {
-		if(procedureId == null) {
-			String msg = "Missing procedure Id to fetch details";
-			throw new OneOpsClientAPIException(msg);
-		}
-		
-		RequestSpecification request = createRequest();
-		ResourceObject ro = new ResourceObject();
-		Map<String ,String> properties= new HashMap<String ,String>();
-		
-		properties.put("procedureState", "canceled");
-		properties.put("definition", null);
-		properties.put("actions", null);
-		properties.put("procedureCiId", null);
-		properties.put("procedureId", null);
-		ro.setProperties(properties);
-		
-		JSONObject jsonObject = JsonUtil.createJsonObject(ro , "cms_procedure");
-		Response response = request.body(jsonObject.toString()).put(IConstants.OPERATION_URI +  IConstants.PROCEDURES_URI + procedureId);
-		
-		if(response != null) {
-			if(response.getStatusCode() == 200 || response.getStatusCode() == 302) {
-				return response.getBody().as(Procedure.class);
-			} else {
-				String msg = String.format("Failed to cancel procedure due to %s", response.getStatusLine());
-				throw new OneOpsClientAPIException(msg);
-			}
-		} 
-		
-		String msg = String.format("Failed to cancel procedure with the given Id %s due to null response", procedureId);
-		throw new OneOpsClientAPIException(msg);
-	}
-	
-	/**
-	 * Execute procedure for a given platform
-	 * 
-	 * @return
-	 * @throws OneOpsClientAPIException
-	 */
-	public Procedure executeAction(String platformName, String componentName, String actionName, List<Long> instanceList, String arglist, int rollingPercent) throws OneOpsClientAPIException {
-		if(platformName == null || platformName.length() == 0) {
-			String msg = "Missing platform name to fetch details";
-			throw new OneOpsClientAPIException(msg);
-		}
-		if(componentName == null || componentName.length() == 0) {
-			String msg = "Missing component name to fetch details";
-			throw new OneOpsClientAPIException(msg);
-		}
-		if(actionName == null || actionName.length() == 0) {
-			String msg = "Missing action name to fetch details";
-			throw new OneOpsClientAPIException(msg);
-		}
-		if(instanceList == null || instanceList.size() == 0) {
-			String msg = "Missing instances list to fetch details";
-			throw new OneOpsClientAPIException(msg);
-		}
-		
-		RequestSpecification request = createRequest();
-		ResourceObject ro = new ResourceObject();
-		Map<String ,String> properties= new HashMap<String ,String>();
-		
-		Transition transition = new Transition(instance, this.assemblyName);
-		CiResource component = transition.getPlatformComponent(this.environmentName, platformName, componentName);
-		Long componentId = component.getCiId();
-		properties.put("procedureState", "active");
-		properties.put("arglist", arglist);
-		
-		properties.put("ciId", "" +  componentId);
-		properties.put("force", "true");
-		properties.put("procedureCiId", "0");
-		
-		Map<String ,Object> flow = Maps.newHashMap();
-		flow.put("targetIds", instanceList);
-		flow.put("relationName", "base.RealizedAs");
-		flow.put("direction", "from");
-		
-		Map<String ,Object> action = Maps.newHashMap();
-		action.put("isInheritable", null);
-		action.put("actionName", "base.RealizedAs");
-		action.put("inherited", null);
-		action.put("isCritical", "true");
-		action.put("stepNumber", "1");
-		action.put("extraInfo", null);
-		action.put("actionName", actionName);
-		
-		List<Map<String ,Object>> actions = Lists.newArrayList();
-		actions.add(action);
-		flow.put("actions", actions);
-		
-		Map<String ,Object> definition = new HashMap<String ,Object>();
-		List<Map<String ,Object>> flows = Lists.newArrayList();
-		flows.add(flow);
-		definition.put("flow", flows);
-		definition.put("name", actionName);
-		
-		properties.put("definition", definition.toString());
-		ro.setProperties(properties);
-		
-		JSONObject jsonObject = JsonUtil.createJsonObject(ro , "cms_procedure");
-		Response response = request.body(jsonObject.toString()).post(IConstants.OPERATION_URI +  IConstants.PROCEDURES_URI);
-		if(response != null) {
-			if(response.getStatusCode() == 200 || response.getStatusCode() == 302) {
-				return response.getBody().as(Procedure.class);
-			} else {
-				String msg = String.format("Failed to execute procedures due to %s", response.getStatusLine());
-				throw new OneOpsClientAPIException(msg);
-			}
-		} 
-		String msg = "Failed to execute procedures due to null response";
-		throw new OneOpsClientAPIException(msg);
-	}
-	
-	public CiResource updatePlatformAutoHealingStatus(String environmentName, String platformName, String healingOption, boolean isEnabled) throws OneOpsClientAPIException {
-		if (environmentName == null || environmentName.length() == 0) {
-			String msg = String.format("Missing environment name to be updated");
-			throw new OneOpsClientAPIException(msg);
-		}
+  public Operation(OOInstance instance, String assemblyName, String environmentName) throws OneOpsClientAPIException {
+    super(instance);
+    if (assemblyName == null || assemblyName.length() == 0) {
+      String msg = "Missing assembly name";
+      throw new OneOpsClientAPIException(msg);
+    }
 
-		if (platformName == null || platformName.length() == 0) {
-			String msg = String.format("Missing platform name to be updated");
-			throw new OneOpsClientAPIException(msg);
-		}
+    if (environmentName == null || environmentName.length() == 0) {
+      String msg = "Missing environment name";
+      throw new OneOpsClientAPIException(msg);
+    }
 
-		if (healingOption == null || healingOption.length() == 0) {
-			String msg = String.format("No healing options available to be updated");
-			throw new OneOpsClientAPIException(msg);
-		}
+    this.assemblyName = assemblyName;
+    this.environmentName = environmentName;
+  }
 
-		RequestSpecification request = createRequest();
-		
-		String enabled = "disable";
-		if(isEnabled) {
-			enabled = "enable";
-		}
-		
-		Response response = request.body("").queryParam("status", enabled)
-				.put(operationURI + IConstants.PLATFORM_URI + platformName + "/" + healingOption);
-		if (response != null) {
-			if (response.getStatusCode() == 200 || response.getStatusCode() == 302) {
-				return response.getBody().as(CiResource.class);
-			} else {
-				String msg = String.format("Failed to update platforms due to %s", response.getStatusLine());
-				throw new OneOpsClientAPIException(msg);
-			}
-		}
-		String msg = String.format("Failed to update platforms due to null response");
-		throw new OneOpsClientAPIException(msg);
-	}
-	
-	public CiResource updatePlatformAutoReplaceConfig(String environmentName, String platformName, int repairCount, int repairTime) throws OneOpsClientAPIException {
-		if (environmentName == null || environmentName.length() == 0) {
-			String msg = String.format("Missing environment name to be updated");
-			throw new OneOpsClientAPIException(msg);
-		}
+  @Deprecated
+  public List<CiResource> listInstances(String platformName, String componentName) throws OneOpsClientAPIException {
+    return super.listInstances(assemblyName, environmentName, platformName, componentName);
+  }
 
-		if (platformName == null || platformName.length() == 0) {
-			String msg = String.format("Missing platform name to be updated");
-			throw new OneOpsClientAPIException(msg);
-		}
+  @Deprecated
+  public Boolean markInstancesForReplacement(String platformName, String componentName) throws OneOpsClientAPIException {
+    return super.markInstancesForReplacement(assemblyName, environmentName, platformName, componentName);
+  }
 
-		RequestSpecification request = createRequest();
-		JSONObject jo = new JSONObject();
-		jo.put("replace_after_minutes", String.valueOf(repairTime));
-		jo.put("replace_after_repairs", String.valueOf(repairCount));
-		
-		Response response = request.body(jo.toString())
-				.put(operationURI + IConstants.PLATFORM_URI + platformName + "/autoreplace");
-		if (response != null) {
-			if (response.getStatusCode() == 200 || response.getStatusCode() == 302) {
-				return response.getBody().as(CiResource.class);
-			} else {
-				String msg = String.format("Failed to update platforms due to %s", response.getStatusLine());
-				throw new OneOpsClientAPIException(msg);
-			}
-		}
-		String msg = String.format("Failed to update platforms due to null response");
-		throw new OneOpsClientAPIException(msg);
-	}
+  @Deprecated
+  public Boolean markInstanceForReplacement(String platformName, String componentName, Long instanceId) throws OneOpsClientAPIException {
+    return super.markInstanceForReplacement(assemblyName, platformName, componentName, instanceId);
+  }
+
+  @Deprecated
+  public JsonPath getLogData(String procedureId, List<String> actionIds) throws OneOpsClientAPIException {
+    return super.getLogData(procedureId, actionIds);
+  }
+
+  @Deprecated
+  public List<CiResource> listProcedures(String platformName) throws OneOpsClientAPIException {
+    return super.listProcedures(assemblyName, environmentName, platformName);
+  }
+
+  @Deprecated
+  public Long getProcedureId(String platformName, String procedureName) throws OneOpsClientAPIException {
+    return super.getProcedureId(assemblyName, environmentName, platformName, procedureName);
+  }
+
+  @Deprecated
+  public JsonPath listActions(String platformName, String componentName) throws OneOpsClientAPIException {
+    return super.listActions(assemblyName, environmentName, platformName, componentName);
+  }
+
+  @Deprecated
+  public Procedure executeProcedure(String platformName, String procedureName, String arglist) throws OneOpsClientAPIException {
+    return super.executeProcedure(assemblyName, environmentName, platformName, procedureName, arglist);
+  }
+
+  @Deprecated
+  public Procedure getProcedureStatus(Long procedureId) throws OneOpsClientAPIException {
+    return super.getProcedureStatus(procedureId);
+  }
+
+  @Deprecated
+  public Procedure cancelProcedure(Long procedureId) throws OneOpsClientAPIException {
+    return super.cancelProcedure(procedureId);
+  }
+
+  @Deprecated
+  public Procedure executeAction(String platformName, String componentName, String actionName, List<Long> instanceList, String arglist, int rollingPercent) throws OneOpsClientAPIException {
+    return super.executeAction(assemblyName, environmentName, platformName, componentName, actionName, instanceList, arglist, rollingPercent);
+  }
+
+  public CiResource updatePlatformAutoHealingStatus(String environmentName, String platformName, String healingOption, boolean isEnabled) throws OneOpsClientAPIException {
+    return super.updatePlatformAutoHealingStatus(assemblyName, environmentName, platformName, healingOption, isEnabled);
+  }
+
+  public CiResource updatePlatformAutoReplaceConfig(String environmentName, String platformName, int repairCount, int repairTime) throws OneOpsClientAPIException {
+    return super.updatePlatformAutoReplaceConfig(assemblyName, environmentName, platformName, repairCount, repairTime);
+  }
 }

--- a/src/main/java/com/oneops/api/resource/Transition.java
+++ b/src/main/java/com/oneops/api/resource/Transition.java
@@ -1,1569 +1,227 @@
 package com.oneops.api.resource;
 
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Map.Entry;
-import java.util.concurrent.TimeUnit;
 
-import org.json.JSONObject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.google.common.base.Strings;
-import com.google.common.collect.Lists;
-import com.google.common.collect.Maps;
-import com.google.common.util.concurrent.Uninterruptibles;
-import com.jayway.restassured.path.json.JsonPath;
-import com.jayway.restassured.response.Response;
-import com.jayway.restassured.specification.RequestSpecification;
 import com.oneops.api.APIClient;
 import com.oneops.api.OOInstance;
-import com.oneops.api.ResourceObject;
 import com.oneops.api.exception.OneOpsClientAPIException;
-import com.oneops.api.resource.model.AttrProps;
-import com.oneops.api.resource.model.CiAttributes;
 import com.oneops.api.resource.model.CiResource;
 import com.oneops.api.resource.model.Deployment;
 import com.oneops.api.resource.model.DeploymentRFC;
 import com.oneops.api.resource.model.Log;
 import com.oneops.api.resource.model.RedundancyConfig;
 import com.oneops.api.resource.model.Release;
-import com.oneops.api.util.IConstants;
-import com.oneops.api.util.JsonUtil;
 
+@Deprecated
 public class Transition extends APIClient {
-	
-	private static final Logger LOG = LoggerFactory.getLogger(Transition.class);
-	private String transitionEnvUri;
-	private OOInstance instance;
-	private String assemblyName;
-	
-	public Transition(OOInstance instance, String assemblyName) throws OneOpsClientAPIException {
-		super(instance);
-		if(assemblyName == null || assemblyName.length() == 0) {
-			String msg = "Missing assembly name";
-			throw new OneOpsClientAPIException(msg);
-		}
-		this.assemblyName = assemblyName;
-		this.instance = instance;
-		transitionEnvUri = IConstants.ASSEMBLY_URI + assemblyName + IConstants.TRANSITION_URI + IConstants.ENVIRONMENT_URI;
-	}
-	
-	/**
-	 * Fetches specific environment details
-	 * 
-	 * @param environmentName
-	 * @return
-	 * @throws OneOpsClientAPIException
-	 */
-	public CiResource getEnvironment(String environmentName) throws OneOpsClientAPIException {
-		if(environmentName == null || environmentName.length() == 0) {
-			String msg = "Missing environment name to fetch details";
-			throw new OneOpsClientAPIException(msg);
-		}
-		
-		RequestSpecification request = createRequest();
-		Response response = request.get(transitionEnvUri + environmentName);
-		if(response != null) {
-			if(response.getStatusCode() == 200 || response.getStatusCode() == 302) {
-				return response.getBody().as(CiResource.class);
-			} else {
-				String msg = String.format("Failed to get environment with name %s due to %s", environmentName, response.getStatusLine());
-				throw new OneOpsClientAPIException(msg);
-			}
-		} 
-		String msg = String.format("Failed to get environment with name %s due to null response", environmentName);
-		throw new OneOpsClientAPIException(msg);
-	}
-	
-	
-	/**
-	 * Lists all environments for a given assembly
-	 * @return
-	 * @throws OneOpsClientAPIException
-	 */
-	public List<CiResource> listEnvironments() throws OneOpsClientAPIException {
-		
-		RequestSpecification request = createRequest();
-		Response response = request.get(transitionEnvUri);
-		if(response != null) {
-			if(response.getStatusCode() == 200 || response.getStatusCode() == 302) {
-				return JsonUtil.toObject(response.getBody().asString(), new TypeReference<List<CiResource>>(){});
-			} else {
-				String msg = String.format("Failed to list environments due to %s", response.getStatusLine());
-				throw new OneOpsClientAPIException(msg);
-			}
-		} 
-		String msg = "Failed to list environments due to null response";
-		throw new OneOpsClientAPIException(msg);
-	}
-	
-	/**
-	 * Creates environment within the given assembly
-	 * 
-	 * @param environmentName {mandatory}
-	 * @param envprofile if exists
-	 * @param availability {mandatory}
-	 * @param platformAvailability
-	 * @param cloudMap {mandatory}
-	 * @param debugFlag {mandatory}
-	 * @param gdnsFlag {mandatory}
-	 * @param description
-	 * @return
-	 * @throws OneOpsClientAPIException
-	 */
-	public CiResource createEnvironment(String environmentName, String envprofile, Map<String ,String> attributes, 
-			Map<String, String> platformAvailability , Map<String, Map<String, String>> cloudMap, String description) throws OneOpsClientAPIException {
-		
-		ResourceObject ro = new ResourceObject();
-		Map<String ,String> properties= new HashMap<String ,String>();
-		
-		if(environmentName != null && environmentName.length() > 0) {
-			properties.put("ciName", environmentName);
-		} else {
-			String msg = "Missing environment name to create environment";
-			throw new OneOpsClientAPIException(msg);
-		}
-		if(attributes == null) {
-			String msg = "Missing availability in attributes map to create environment";
-			throw new OneOpsClientAPIException(msg);
-		}
-		
-		properties.put("nsPath", instance.getOrgname() + "/" + assemblyName);
-		
-		String availability = null;
-		if(attributes.containsKey("availability")) {
-			availability = attributes.get("availability");
-		} else {
-			String msg = "Missing availability in attributes map to create environment";
-			throw new OneOpsClientAPIException(msg);
-		}
-		
-		if(attributes.containsKey("global_dns")) {
-			attributes.put("global_dns", String.valueOf(attributes.get("global_dns")));
-		}
-		
-		ro.setProperties(properties);
-		attributes.put("profile", envprofile);
-		attributes.put("description", description);
-		String subdomain = environmentName + "." + assemblyName + "." + instance.getOrgname();
-		attributes.put("subdomain", subdomain);
-		ro.setAttributes(attributes);
-		
-		RequestSpecification request = createRequest();
-		JSONObject jsonObject = JsonUtil.createJsonObject(ro , "cms_ci");
-		if(platformAvailability == null || platformAvailability.size() == 0) {
-			Design design = new Design(instance, assemblyName);
-			List<CiResource> platforms = design.listPlatforms();
-			if(platforms != null) {
-				platformAvailability = new HashMap<String, String>();
-				for (CiResource platform : platforms) {
-					platformAvailability.put(platform.getCiId() + "", availability);
-				}
-			}
-		}
-		jsonObject.put("platform_availability", platformAvailability);
-		
-		if(cloudMap == null || cloudMap.size() == 0) {
-			String msg = "Missing clouds map to create environment";
-			throw new OneOpsClientAPIException(msg);
-		}
-		jsonObject.put("clouds", cloudMap);
-		
-		Response response = request.body(jsonObject.toString()).post(transitionEnvUri);
-		
-		if(response != null) {
-			if(response.getStatusCode() == 200 || response.getStatusCode() == 302) {
-				return response.getBody().as(CiResource.class);
-			} else {
-				String msg = String.format("Failed to create environment with name %s due to %s", environmentName, response.getStatusLine());
-				throw new OneOpsClientAPIException(msg);
-			}
-		} 
-		String msg = String.format("Failed to create environment with name %s due to null response", environmentName);
-		throw new OneOpsClientAPIException(msg);
-	}
-	
 
-	/**
-	 * Commits environment open releases
-	 * 
-	 * @param environmentName {mandatory}
-	 * @param excludePlatforms
-	 * @return
-	 * @throws OneOpsClientAPIException
-	 */
-	public Release commitEnvironment(String environmentName, List<Long> excludePlatforms, String comment) throws OneOpsClientAPIException {
-		
-		RequestSpecification request = createRequest();
-		JSONObject jo = new JSONObject();
-		if(excludePlatforms != null && excludePlatforms.size() > 0) {
-			StringBuilder sb = new StringBuilder();
-			for (int i = 0; i < excludePlatforms.size(); i++) {
-				sb.append(excludePlatforms.get(i));
-				if(i < (excludePlatforms.size() - 1)){
-					sb.append(",");
-				}
-			}
-			jo.put("exclude_platforms", sb.toString());
-		}
-		if(comment != null)
-			jo.put("desc", comment);
-		Response response = request.body(jo.toString()).post(transitionEnvUri + environmentName + "/commit");
-		if(response != null) {
-			if(response.getStatusCode() == 200 || response.getStatusCode() == 302) {
-				
-				response = request.get(transitionEnvUri + environmentName);
-				String envState = response.getBody().jsonPath().get("ciState");
-				//wait for deployment plan to generate
-				do {
-					Uninterruptibles.sleepUninterruptibly(5, TimeUnit.SECONDS);
-					response = request.get(transitionEnvUri + environmentName);
-					if(response == null) {
-						String msg = String.format("Failed to commit environment due to null response");
-						throw new OneOpsClientAPIException(msg);
-					}
-					envState = response.getBody().jsonPath().get("ciState");
-				} while(response != null && "locked".equalsIgnoreCase(envState));
-				
-				String comments = response.getBody().jsonPath().getString("comments");
-				if(comments != null && comments.startsWith("ERROR:")) {
-					String msg = String.format("Failed to commit environment due to %s",  comments);
-					throw new OneOpsClientAPIException(msg);
-				}
-				
-				return response.getBody().as(Release.class);
-				
-			} else {
-				String msg = String.format("Failed to commit environment due to %s",  response.getStatusLine());
-				throw new OneOpsClientAPIException(msg);
-			}
-		} 
-		String msg = "Failed to commit environment due to null response";
-		throw new OneOpsClientAPIException(msg);
-	}
-	
-	/**
-	 * Deploy an already generated deployment plan
-	 * 
-	 * @param environmentName
-	 * @return
-	 * @throws OneOpsClientAPIException
-	 */
-	public Deployment deploy(String environmentName, String comments) throws OneOpsClientAPIException {
-		
-		RequestSpecification request = createRequest();
-		
-		 Release bomRelease = getBomRelease(environmentName);
-		 Long releaseId = bomRelease.getReleaseId();
-		 String nsPath = bomRelease.getNsPath();
-		 if(releaseId != null && nsPath!= null) {
-			Map<String ,String> properties= new HashMap<String ,String>();
-			properties.put("nsPath", nsPath);
-			properties.put("releaseId", releaseId + "");
-			if(comments != null) {
-				properties.put("comments", comments);
-			}
-			ResourceObject ro = new ResourceObject();
-			ro.setProperties(properties);
-			JSONObject jsonObject = JsonUtil.createJsonObject(ro , "cms_deployment");
-			Response response = request.body(jsonObject.toString()).post(transitionEnvUri + environmentName + "/deployments/");
-			if(response == null) {
-				String msg = String.format("Failed to start deployment for environment %s due to null response" , environmentName);
-				throw new OneOpsClientAPIException(msg);
-			}
-			if(response.getStatusCode() == 200 || response.getStatusCode() == 302) {
-				return response.getBody().as(Deployment.class);
-			} else {
-				String msg = String.format("Failed to start deployment for environment %s due to null response" , environmentName);
-				throw new OneOpsClientAPIException(msg);
-			}
-		} else {
-			String msg = String.format("Failed to find release id to be deployed");
-			throw new OneOpsClientAPIException(msg);
-		}
-				
-			
-	}
-	
-	
-	/**
-	 * Fetches deployment status for the given assembly/environment
-	 * 
-	 * @param environmentName
-	 * @param deploymentId
-	 * @return
-	 * @throws OneOpsClientAPIException
-	 */
-	public Deployment getDeploymentStatus(String environmentName, Long deploymentId) throws OneOpsClientAPIException {
-		if(environmentName == null || environmentName.length() == 0) {
-			String msg = "Missing environment name to fetch details";
-			throw new OneOpsClientAPIException(msg);
-		}
-		if(deploymentId == null) {
-			String msg = "Missing deployment to fetch details";
-			throw new OneOpsClientAPIException(msg);
-		}
-		
-		RequestSpecification request = createRequest();
-		Response response = request.get(transitionEnvUri + environmentName + IConstants.DEPLOYMENTS_URI + deploymentId + "/status");
-		if(response != null) {
-			if(response.getStatusCode() == 200 || response.getStatusCode() == 302) {
-				return response.getBody().as(Deployment.class);
-			} else {
-				String msg = String.format("Failed to get deployment status for environment %s with deployment Id %s due to %s", environmentName, deploymentId, response.getStatusLine());
-				throw new OneOpsClientAPIException(msg);
-			}
-		} 
-		String msg = String.format("Failed to get deployment status for environment %s with deployment Id %s due to null response", environmentName, deploymentId);
-		throw new OneOpsClientAPIException(msg);
-	}
-	
-	/**
-	 * Fetches latest deployment for the given assembly/environment
-	 * 
-	 * @param environmentName
-	 * @return
-	 * @throws OneOpsClientAPIException
-	 */
-	public Deployment getLatestDeployment(String environmentName) throws OneOpsClientAPIException {
-		if(environmentName == null || environmentName.length() == 0) {
-			String msg = "Missing environment name to fetch details";
-			throw new OneOpsClientAPIException(msg);
-		}
-		
-		RequestSpecification request = createRequest();
-		Response response = request.get(transitionEnvUri + environmentName + IConstants.DEPLOYMENTS_URI + "latest" );
-		if(response != null) {
-			if(response.getStatusCode() == 200 || response.getStatusCode() == 302) {
-				return response.getBody().as(Deployment.class);
-			} else {
-				String msg = String.format("Failed to get latest deployment for environment %s due to %s", environmentName, response.getStatusLine());
-				throw new OneOpsClientAPIException(msg);
-			}
-		} 
-		String msg = String.format("Failed to get latest deployment for environment %s due to null response", environmentName);
-		throw new OneOpsClientAPIException(msg);
-	}
-	
-	
-	/**
-	 * Discard already generated deployment plan
-	 * 
-	 * @param environmentName
-	 * @return
-	 * @throws OneOpsClientAPIException
-	 */
-	public Release discardDeploymentPlan(String environmentName) throws OneOpsClientAPIException {
-		if(environmentName == null || environmentName.length() == 0) {
-			String msg = "Missing environment name to fetch details";
-			throw new OneOpsClientAPIException(msg);
-		}
-		
-		RequestSpecification request = createRequest();
-		
-		Release bomRelease = getBomRelease(environmentName);
-		if(bomRelease != null) {
-			long releaseId = bomRelease.getReleaseId();
-			Response response = request.body("").post(transitionEnvUri + environmentName + IConstants.RELEASES_URI + releaseId + "/discard" );
-			if(response != null) {
-				if(response.getStatusCode() == 200 || response.getStatusCode() == 302) {
-					return response.getBody().as(Release.class);
-				} else {
-					String msg = String.format("Failed to discard deployment plan for environment %s due to %s", environmentName, response.getStatusLine());
-					throw new OneOpsClientAPIException(msg);
-				}
-			} 
-		} else {
-			String msg = String.format("Failed to discard deployment plan for environment %s due to no open bom", environmentName);
-			throw new OneOpsClientAPIException(msg);
-		}
-		
-		String msg = String.format("Failed to discard deployment plan for environment %s due to null response", environmentName);
-		throw new OneOpsClientAPIException(msg);
-	}
-	
-	/**
-	 * Discard uncommitted changes for the given {environmentName}
-	 * 
-	 * @param environmentName
-	 * @return
-	 * @throws OneOpsClientAPIException
-	 */
-	public Release discardOpenRelease(String environmentName) throws OneOpsClientAPIException {
-		if(environmentName == null || environmentName.length() == 0) {
-			String msg = "Missing environment name to fetch details";
-			throw new OneOpsClientAPIException(msg);
-		}
-		
-		RequestSpecification request = createRequest();
-		Response response = request.body("").post(transitionEnvUri + environmentName + "/discard" );
-		if(response != null) {
-			if(response.getStatusCode() == 200 || response.getStatusCode() == 302) {
-				return response.getBody().as(Release.class);
-			} else {
-				String msg = String.format("Failed to discard changes for environment %s due to %s", environmentName, response.getStatusLine());
-				throw new OneOpsClientAPIException(msg);
-			}
-		} 
-		
-		String msg = String.format("Failed to discard changes for environment %s due to null response", environmentName);
-		throw new OneOpsClientAPIException(msg);
-	}
-	
-	/**
-	 * Disable all platforms for the given assembly/environment
-	 * 
-	 * @param environmentName
-	 * @return
-	 * @throws OneOpsClientAPIException
-	 */
-	public CiResource disableAllPlatforms(String environmentName) throws OneOpsClientAPIException {
-		if(environmentName == null || environmentName.length() == 0) {
-			String msg = "Missing environment name to disable all platforms";
-			throw new OneOpsClientAPIException(msg);
-		}
-		
-		List<CiResource> ps = listPlatforms(environmentName);
-		List<Long> platformIds = Lists.newArrayList();
-		for (CiResource ciResource : ps) {
-			platformIds.add(ciResource.getCiId());
-		}
-		
-		RequestSpecification request = createRequest();
-		Response response = request.queryParam("platformCiIds[]", platformIds).put(transitionEnvUri + environmentName + "/disable" );
-		if(response != null) {
-			if(response.getStatusCode() == 200 || response.getStatusCode() == 302) {
-				return response.getBody().as(CiResource.class);
-			} else {
-				String msg = String.format("Failed to disable platforms for environment %s due to %s", environmentName, response.getStatusLine());
-				throw new OneOpsClientAPIException(msg);
-			}
-		} 
-		String msg = String.format("Failed to disable platforms for environment %s due to null response", environmentName);
-		throw new OneOpsClientAPIException(msg);
-	}
-	
-	/**
-	 * Fetches latest release for the given assembly/environment
-	 * 
-	 * @param environmentName
-	 * @return
-	 * @throws OneOpsClientAPIException
-	 */
-	public Release getLatestRelease(String environmentName) throws OneOpsClientAPIException {
-		if(environmentName == null || environmentName.length() == 0) {
-			String msg = "Missing environment name to fetch details";
-			throw new OneOpsClientAPIException(msg);
-		}
-		
-		RequestSpecification request = createRequest();
-		Response response = request.get(transitionEnvUri + environmentName + IConstants.RELEASES_URI + "latest" );
-		if(response != null) {
-			if(response.getStatusCode() == 200 || response.getStatusCode() == 302) {
-				return response.getBody().as(Release.class);
-			} else {
-				String msg = String.format("Failed to get latest releases for environment %s due to %s", environmentName, response.getStatusLine());
-				throw new OneOpsClientAPIException(msg);
-			}
-		} 
-		String msg = String.format("Failed to get latest releases for environment %s due to null response", environmentName);
-		throw new OneOpsClientAPIException(msg);
-	}
-	
-	
-	/**
-	 * Fetches bom release for the given assembly/environment
-	 * 
-	 * @param environmentName
-	 * @return
-	 * @throws OneOpsClientAPIException
-	 */
-	public Release getBomRelease(String environmentName) throws OneOpsClientAPIException {
-		if(environmentName == null || environmentName.length() == 0) {
-			String msg = "Missing environment name to fetch details";
-			throw new OneOpsClientAPIException(msg);
-		}
-		
-		RequestSpecification request = createRequest();
-		Response response = request.get(transitionEnvUri + environmentName + IConstants.RELEASES_URI + "bom" );
-		if(response != null) {
-			if(response.getStatusCode() == 200 || response.getStatusCode() == 302) {
-				return response.getBody().as(Release.class);
-			} else {
-				String msg = String.format("No bom releases found for environment %s ", environmentName);
-				LOG.error(msg);
-				return null;
-			}
-		} 
-		String msg = String.format("Failed to get bom releases for environment %s due to null response", environmentName);
-		throw new OneOpsClientAPIException(msg);
-	}
-	
-	
-	/**
-	 * Cancels a failed/paused deployment
-	 * 
-	 * @param environmentName
-	 * @param deploymentId
-	 * @param releaseId
-	 * @return
-	 * @throws OneOpsClientAPIException
-	 */
-	public Deployment cancelDeployment(String environmentName, Long deploymentId, Long releaseId) throws OneOpsClientAPIException {
-		return updateDeploymentStatus(environmentName, deploymentId, releaseId, "canceled");
-	}
-	
-	
-	public DeploymentRFC getDeployment(String environmentName, Long deploymentId) throws OneOpsClientAPIException {
-		if(environmentName == null || environmentName.length() == 0) {
-			String msg = "Missing environment name to fetch details";
-			throw new OneOpsClientAPIException(msg);
-		}
-		
-		if(deploymentId == null) {
-			String msg = "Missing deployment Id to fetch details";
-			throw new OneOpsClientAPIException(msg);
-		}
-		
-		RequestSpecification request = createRequest();
-		Response response = request.get(transitionEnvUri + environmentName + IConstants.DEPLOYMENTS_URI + deploymentId );
-		if(response != null) {
-			if(response.getStatusCode() == 200 || response.getStatusCode() == 302) {
-				return response.getBody().as(DeploymentRFC.class);
-			} else {
-				String msg = String.format("Failed to get deployment details for environment %s for id %s due to %s", environmentName, deploymentId, response.getStatusLine());
-				throw new OneOpsClientAPIException(msg);
-			}
-		} 
-		String msg = String.format("Failed to get deployment details for environment %s for id %s due to null response", environmentName, deploymentId);
-		throw new OneOpsClientAPIException(msg);
-	}
-	
-	public Log getDeploymentRfcLog(String environmentName, Long deploymentId, Long rfcId) throws OneOpsClientAPIException {
-		if(environmentName == null || environmentName.length() == 0) {
-			String msg = "Missing environment name to fetch details";
-			throw new OneOpsClientAPIException(msg);
-		}
-		
-		if(deploymentId == null) {
-			String msg = "Missing deployment Id to fetch details";
-			throw new OneOpsClientAPIException(msg);
-		}
-		
-		if(rfcId == null ) {
-			String msg = "Missing rfc Id to fetch details";
-			throw new OneOpsClientAPIException(msg);
-		}
-		
-		RequestSpecification request = createRequest();
-		Response response = request.queryParam("rfcId", rfcId).get(transitionEnvUri + environmentName + IConstants.DEPLOYMENTS_URI + deploymentId + "/log_data");
-		if(response != null) {
-			if(response.getStatusCode() == 200 || response.getStatusCode() == 302) {
-				return response.getBody().as(Log.class);
-			} else {
-				String msg = String.format("Failed to get deployment logs for environment %s, deployment id %s and rfcId %s due to %s", environmentName, deploymentId, rfcId, response.getStatusLine());
-				throw new OneOpsClientAPIException(msg);
-			}
-		} 
-		String msg = String.format("Failed to get deployment logs for environment %s, deployment id %s and rfcId %s due to null response", environmentName, deploymentId, rfcId);
-		throw new OneOpsClientAPIException(msg);
-	}
-	
-	/**
-	 * Approve a deployment
-	 * 
-	 * @param environmentName
-	 * @param deploymentId
-	 * @param releaseId
-	 * @return
-	 * @throws OneOpsClientAPIException
-	 */
-	public Deployment approveDeployment(String environmentName, Long deploymentId, Long releaseId) throws OneOpsClientAPIException {
-		return updateDeploymentStatus(environmentName, deploymentId, releaseId, "active");
-	}
-	
-	/**
-	 * Retry a deployment
-	 * 
-	 * @param environmentName
-	 * @param deploymentId
-	 * @param releaseId
-	 * @return
-	 * @throws OneOpsClientAPIException
-	 */
-	public Deployment retryDeployment(String environmentName, Long deploymentId, Long releaseId) throws OneOpsClientAPIException {
-		return updateDeploymentStatus(environmentName, deploymentId, releaseId, "active");
-	}
-	
-	/**
-	 * Update deployment state
-	 * 
-	 * @param environmentName
-	 * @param deploymentId
-	 * @param releaseId
-	 * @return
-	 * @throws OneOpsClientAPIException
-	 */
-	private Deployment updateDeploymentStatus(String environmentName, Long deploymentId, Long releaseId, String newstate) throws OneOpsClientAPIException {
-		if(environmentName == null || environmentName.length() == 0) {
-			String msg = "Missing environment name to fetch details";
-			throw new OneOpsClientAPIException(msg);
-		}
-		if(deploymentId == null ) {
-			String msg = "Missing deployment to fetch details";
-			throw new OneOpsClientAPIException(msg);
-		}
-		
-		RequestSpecification request = createRequest();
-		
-		Map<String ,String> properties= new HashMap<String ,String>();
-		properties.put("deploymentState", newstate);
-		properties.put("releaseId", String.valueOf(releaseId));
-		ResourceObject ro = new ResourceObject();
-		ro.setProperties(properties);
-		JSONObject jsonObject = JsonUtil.createJsonObject(ro , "cms_deployment");
-		
-		Response response = request.body(jsonObject.toString()).put(transitionEnvUri + environmentName + IConstants.DEPLOYMENTS_URI + deploymentId);
-		if(response != null) {
-			if(response.getStatusCode() == 200 || response.getStatusCode() == 302) {
-				return response.getBody().as(Deployment.class);
-			} else {
-				String msg = String.format("Failed to update deployment state to %s for environment %s with deployment Id %s due to %s", newstate, environmentName, deploymentId, response.getStatusLine());
-				throw new OneOpsClientAPIException(msg);
-			}
-		} 
-		String msg = String.format("Failed to update deployment state to %s for environment %s with deployment Id %s due to null response", newstate, environmentName, deploymentId);
-		throw new OneOpsClientAPIException(msg);
-	}
-	
-	/**
-	 * Deletes the given environment
-	 * 
-	 * @param environmentName
-	 * @return
-	 * @throws OneOpsClientAPIException
-	 */
-	public CiResource deleteEnvironment(String environmentName) throws OneOpsClientAPIException {
-		if(environmentName == null || environmentName.length() == 0) {
-			String msg = "Missing environment name to delete";
-			throw new OneOpsClientAPIException(msg);
-		}
-		
-		RequestSpecification request = createRequest();
-		Response response = request.delete(transitionEnvUri + environmentName);
-		if(response != null) {
-			if(response.getStatusCode() == 200 || response.getStatusCode() == 302) {
-				return response.getBody().as(CiResource.class);
-			} else {
-				String msg = String.format("Failed to delete environment with name %s due to %s", environmentName, response.getStatusLine());
-				throw new OneOpsClientAPIException(msg);
-			}
-		} 
-		String msg = String.format("Failed to delete environment with name %s due to null response", environmentName);
-		throw new OneOpsClientAPIException(msg);
-	}
-	
-	/**
-	 * List platforms for a given assembly/environment
-	 * 
-	 * @param environmentName
-	 * @return
-	 * @throws OneOpsClientAPIException
-	 */
-	public List<CiResource> listPlatforms(String environmentName) throws OneOpsClientAPIException {
-		if(environmentName == null || environmentName.length() == 0) {
-			String msg = "Missing environment name list platforms";
-			throw new OneOpsClientAPIException(msg);
-		}
-		
-		RequestSpecification request = createRequest();
-		Response response = request.get(transitionEnvUri + environmentName + IConstants.PLATFORM_URI);
-		if(response != null) {
-			if(response.getStatusCode() == 200 || response.getStatusCode() == 302) {
-				return JsonUtil.toObject(response.getBody().asString(), new TypeReference<List<CiResource>>(){});
-			} else {
-				String msg = String.format("Failed to get list of environment platforms due to %s", response.getStatusLine());
-				throw new OneOpsClientAPIException(msg);
-			}
-		} 
-		String msg = "Failed to get list of environment platforms due to null response";
-		throw new OneOpsClientAPIException(msg);
-	}
-	
-	/**
-	 * Get platform details for a given assembly/environment
-	 * 
-	 * @param environmentName
-	 * @param platformName
-	 * @return
-	 * @throws OneOpsClientAPIException
-	 */
-	public CiResource getPlatform(String environmentName, String platformName) throws OneOpsClientAPIException {
-		if(environmentName == null || environmentName.length() == 0) {
-			String msg = "Missing environment name to get details";
-			throw new OneOpsClientAPIException(msg);
-		}
-		if(platformName == null || platformName.length() == 0) {
-			String msg = "Missing platform name to get details";
-			throw new OneOpsClientAPIException(msg);
-		}
-		RequestSpecification request = createRequest();
-		Response response = request.get(transitionEnvUri + environmentName + IConstants.PLATFORM_URI + platformName);
-		if(response != null) {
-			if(response.getStatusCode() == 200 || response.getStatusCode() == 302) {
-				return response.getBody().as(CiResource.class);
-			} else {
-				String msg = String.format("Failed to get environment platform details due to %s", response.getStatusLine());
-				throw new OneOpsClientAPIException(msg);
-			}
-		} 
-		String msg = "Failed to get environment platform details due to null response";
-		throw new OneOpsClientAPIException(msg);
-	}
-	
-	/**
-	 * List platform components for a given assembly/environment/platform
-	 * 
-	 * @param environmentName
-	 * @param platformName
-	 * @return
-	 * @throws OneOpsClientAPIException
-	 */
-	public List<CiResource> listPlatformComponents(String environmentName, String platformName) throws OneOpsClientAPIException {
-		if(environmentName == null || environmentName.length() == 0) {
-			String msg = "Missing environment name to list enviornment platform components";
-			throw new OneOpsClientAPIException(msg);
-		}
-		if(platformName == null || platformName.length() == 0) {
-			String msg = "Missing platform name to list enviornment platform components";
-			throw new OneOpsClientAPIException(msg);
-		}
-		RequestSpecification request = createRequest();
-		Response response = request.get(transitionEnvUri + environmentName + IConstants.PLATFORM_URI + platformName + IConstants.COMPONENT_URI);
-		if(response != null) {
-			if(response.getStatusCode() == 200 || response.getStatusCode() == 302) {
-				return JsonUtil.toObject(response.getBody().asString(), new TypeReference<List<CiResource>>(){});
-			} else {
-				String msg = String.format("Failed to get list of environment platforms components due to %s", response.getStatusLine());
-				throw new OneOpsClientAPIException(msg);
-			}
-		} 
-		String msg = "Failed to get list of environment platforms components due to null response";
-		throw new OneOpsClientAPIException(msg);
-	}
-	
-	/**
-	 * Get platform component details for a given assembly/environment/platform
-	 * 
-	 * @param environmentName
-	 * @param platformName
-	 * @param componentName
-	 * @return
-	 * @throws OneOpsClientAPIException
-	 */
-	public CiResource getPlatformComponent(String environmentName, String platformName, String componentName) throws OneOpsClientAPIException {
-		if(environmentName == null || environmentName.length() == 0) {
-			String msg = "Missing environment name to get enviornment platform component details";
-			throw new OneOpsClientAPIException(msg);
-		}
-		if(platformName == null || platformName.length() == 0) {
-			String msg = "Missing platform name to get enviornment platform component details";
-			throw new OneOpsClientAPIException(msg);
-		}
-		if(componentName == null || componentName.length() == 0) {
-			String msg = "Missing component name to get enviornment platform component details";
-			throw new OneOpsClientAPIException(msg);
-		}
-		RequestSpecification request = createRequest();
-		Response response = request.get(transitionEnvUri + environmentName + IConstants.PLATFORM_URI + platformName + IConstants.COMPONENT_URI + componentName);
-		if(response != null) {
-			if(response.getStatusCode() == 200 || response.getStatusCode() == 302) {
-				return response.getBody().as(CiResource.class);
-			} else {
-				String msg = String.format("Failed to get enviornment platform component details due to %s", response.getStatusLine());
-				throw new OneOpsClientAPIException(msg);
-			}
-		} 
-		String msg = "Failed to get enviornment platform component details due to null response";
-		throw new OneOpsClientAPIException(msg);
-	}
-	
-	/**
-	 * Update component attributes for a given assembly/environment/platform/component
-	 * 
-	 * @param environmentName
-	 * @param platformName
-	 * @param componentName
-	 * @param attributes
-	 * @return
-	 * @throws OneOpsClientAPIException
-	 */
-	public CiResource updatePlatformComponent(String environmentName, String platformName, String componentName, Map<String, String> attributes) throws OneOpsClientAPIException {
-		if(environmentName == null || environmentName.length() == 0) {
-			String msg = "Missing environment name to update component attributes";
-			throw new OneOpsClientAPIException(msg);
-		}
-		if(platformName == null || platformName.length() == 0) {
-			String msg = "Missing platform name to update component attributes";
-			throw new OneOpsClientAPIException(msg);
-		}
-		if(componentName == null || componentName.length() == 0) {
-			String msg = "Missing component name to update component attributes";
-			throw new OneOpsClientAPIException(msg);
-		}
-		if(attributes == null || attributes.size() == 0) {
-			String msg = "Missing attributes list to be updated";
-			throw new OneOpsClientAPIException(msg);
-		}
-		
-		CiResource componentDetails = getPlatformComponent(environmentName, platformName, componentName);
-		if(componentDetails != null) {
-			ResourceObject ro = new ResourceObject();
-			
-			Long ciId = componentDetails.getCiId();
-			
-			Map<String, String> attr = Maps.newHashMap();
-			//Add ciAttributes to be updated
-			if(attributes != null && attributes.size() > 0)
-				attr.putAll(attributes);
-			
-			Map<String, String> ownerProps = Maps.newHashMap();
-			//Add existing attrProps to retain locking of attributes 
-			AttrProps attrProps = componentDetails.getAttrProps();
-			if(attrProps != null && attrProps.getAdditionalProperties() != null && attrProps.getAdditionalProperties().size() > 0 && attrProps.getAdditionalProperties().get("owner") != null) {
-				@SuppressWarnings("unchecked")
-				Map<String, String> ownersMap = (Map<String, String>) attrProps.getAdditionalProperties().get("owner");
-				for(Entry<String, String> entry : ownersMap.entrySet()) {
-					ownerProps.put(entry.getKey(), entry.getValue());
-				}
-			}
-			
-			//Add updated attributes to attrProps to lock them
-			for(Entry<String, String> entry :  attributes.entrySet()) {
-				ownerProps.put(entry.getKey(), "manifest");
-			}
-			
-			ro.setAttributes(attr);
-			ro.setOwnerProps(ownerProps);
-			
-			RequestSpecification request = createRequest();
-			JSONObject jsonObject = JsonUtil.createJsonObject(ro , "cms_dj_ci");
- 			Response response = request.body(jsonObject.toString()).put(transitionEnvUri + environmentName + IConstants.PLATFORM_URI + platformName + IConstants.COMPONENT_URI + ciId);
-			if(response != null) {
-				if(response.getStatusCode() == 200 || response.getStatusCode() == 302) {
-					return response.getBody().as(CiResource.class);
-				} else {
-					String msg = String.format("Failed to get update component %s due to %s", componentName, response.getStatusLine());
-					throw new OneOpsClientAPIException(msg);
-				}
-			} 
-		}
-		String msg = String.format("Failed to get update component %s due to null response", componentName);
-		throw new OneOpsClientAPIException(msg);
-	}
-	
-	/**
-	 * touch component
-	 * 
-	 * @param environmentName
-	 * @param platformName
-	 * @param componentName
-	 * @return
-	 * @throws OneOpsClientAPIException
-	 */
-	public CiResource touchPlatformComponent(String environmentName, String platformName, String componentName) throws OneOpsClientAPIException {
-		if(environmentName == null || environmentName.length() == 0) {
-			String msg = "Missing environment name to update component attributes";
-			throw new OneOpsClientAPIException(msg);
-		}
-		if(platformName == null || platformName.length() == 0) {
-			String msg = "Missing platform name to update component attributes";
-			throw new OneOpsClientAPIException(msg);
-		}
-		if(componentName == null || componentName.length() == 0) {
-			String msg = "Missing component name to update component attributes";
-			throw new OneOpsClientAPIException(msg);
-		}
-		
-		RequestSpecification request = createRequest();
-		JSONObject jo = new JSONObject();
-		
-		Response response = request.body(jo.toString()).post(transitionEnvUri + environmentName + IConstants.PLATFORM_URI + platformName + IConstants.COMPONENT_URI + componentName + "/touch");
-		
-		if(response != null) {
-			if(response.getStatusCode() == 200 || response.getStatusCode() == 302) {
-				return response.getBody().as(CiResource.class);
-			} else {
-				String msg = String.format("Failed to touch component %s due to %s", componentName, response.getStatusLine());
-				throw new OneOpsClientAPIException(msg);
-			}
-		} 
-		String msg = String.format("Failed to get touch component %s due to null response", componentName);
-		throw new OneOpsClientAPIException(msg);
-	}
-	
-	/**
-	 * Pull latest design commits
-	 * 
-	 * @param environmentName {mandatory}
-	 * @return
-	 * @throws OneOpsClientAPIException
-	 */
-	public CiResource pullDesign(String environmentName) throws OneOpsClientAPIException {
-		
-		RequestSpecification request = createRequest();
-		JSONObject jo = new JSONObject();
-		
-		Response response = request.body(jo.toString()).post(transitionEnvUri + environmentName + "/pull");
-		if(response != null) {
-			if(response.getStatusCode() == 200 || response.getStatusCode() == 302) {
-				CiResource env = response.getBody().as(CiResource.class);
-				if(env == null || (env.getComments() != null && env.getComments().startsWith("ERROR:"))) {
-					String msg = String.format("Failed to pull design for environment %s due to %s", environmentName, env.getComments());
-					throw new OneOpsClientAPIException(msg);
-				} else 
-					return env;
-			} else {
-				String msg = String.format("Failed to pull design for environment %s due to %s", environmentName, response.getStatusLine());
-				throw new OneOpsClientAPIException(msg);
-			}
-		} 
-		String msg = String.format("Failed to pull design for environment %s due to null response", environmentName);
-		throw new OneOpsClientAPIException(msg);
-	}
-	
-	/**
-	 * Use this pull design when new platform(s) or newer version of platform(s) is being added to the environment
-	 *  
-	 * @param environmentName
-	 * @param platformAvailability
-	 * @return
-	 * @throws OneOpsClientAPIException
-	 */
-	public CiResource pullNewPlatform(String environmentName, Map<String, String> platformAvailability) throws OneOpsClientAPIException {
-		
-		RequestSpecification request = createRequest();
-		JSONObject jo = new JSONObject();
-		
-		if(platformAvailability == null || platformAvailability.size() == 0) {
-			Design design = new Design(instance, assemblyName);
-			List<CiResource> platforms = design.listPlatforms();
-			
-			CiResource env = getEnvironment(environmentName);
-			String availability = "single";
-			if(env != null && env.getCiAttributes() != null) {
-				CiAttributes attr = env.getCiAttributes();//.availability");
-				if(attr.getAdditionalProperties() != null && attr.getAdditionalProperties().containsKey("availability")) {
-					availability = String.valueOf(attr.getAdditionalProperties().get("availability"));
-				}
-			}
-			if(platforms != null) {
-				platformAvailability = new HashMap<String, String>();
-				for (CiResource platform : platforms) {
-					platformAvailability.put(platform.getCiId() + "", availability);
-				}
-			}
-		}
-		jo.put("platform_availability", platformAvailability);
-		
-		Response response = request.body(jo.toString()).post(transitionEnvUri + environmentName + "/pull");
-		if(response != null) {
-			if(response.getStatusCode() == 200 || response.getStatusCode() == 302) {
-				CiResource env = response.getBody().as(CiResource.class);
-				if(env == null || (env.getComments() != null && env.getComments().startsWith("ERROR:"))) {
-					String msg = String.format("Failed to pull design for environment %s due to %s", environmentName, env.getComments());
-					throw new OneOpsClientAPIException(msg);
-				} else 
-					return env;
-			} else {
-				String msg = String.format("Failed to pull design for environment %s due to %s", environmentName, response.getStatusLine());
-				throw new OneOpsClientAPIException(msg);
-			}
-		} 
-		String msg = String.format("Failed to pull design for environment %s due to null response", environmentName);
-		throw new OneOpsClientAPIException(msg);
-	}
-	
-	/**
-	 * List local variables for a given assembly/environment/platform
-	 * 
-	 * @param environmentName
-	 * @param platformName
-	 * @return
-	 * @throws OneOpsClientAPIException
-	 */
-	public List<CiResource> listPlatformVariables(String environmentName, String platformName) throws OneOpsClientAPIException {
-		if(environmentName == null || environmentName.length() == 0) {
-			String msg = "Missing environment name to list enviornment platform variables";
-			throw new OneOpsClientAPIException(msg);
-		}
-		if(platformName == null || platformName.length() == 0) {
-			String msg = "Missing platform name to list enviornment platform variables";
-			throw new OneOpsClientAPIException(msg);
-		}
-		RequestSpecification request = createRequest();
-		Response response = request.get(transitionEnvUri + environmentName + IConstants.PLATFORM_URI + platformName + IConstants.VARIABLES_URI);
-		if(response != null) {
-			if(response.getStatusCode() == 200 || response.getStatusCode() == 302) {
-				return JsonUtil.toObject(response.getBody().asString(), new TypeReference<List<CiResource>>(){});
-			} else {
-				String msg = String.format("Failed to get list of environment platforms variables due to %s", response.getStatusLine());
-				throw new OneOpsClientAPIException(msg);
-			}
-		} 
-		String msg = "Failed to get list of environment platforms variables due to null response";
-		throw new OneOpsClientAPIException(msg);
-	}
-	
-	/**
-	 * Update platform local variables for a given assembly/environment/platform
-	 * 
-	 * @param environmentName
-	 * @param platformName
-	 * @param variables
-	 * @param isSecure
-	 * @return
-	 * @throws OneOpsClientAPIException
-	 */
-	 
-	public Boolean updatePlatformVariable(String environmentName, String platformName, String variableName, String variableValue, boolean isSecure) throws OneOpsClientAPIException {
-		if(environmentName == null || environmentName.length() == 0) {
-			String msg = "Missing environment name to update variables";
-			throw new OneOpsClientAPIException(msg);
-		}
-		if(platformName == null || platformName.length() == 0) {
-			String msg = "Missing platform name to update variables";
-			throw new OneOpsClientAPIException(msg);
-		}
-		if(variableName == null ) {
-			String msg = "Missing variable name to be added";
-			throw new OneOpsClientAPIException(msg);
-		}
-		if(variableValue == null ) {
-			String msg = "Missing variable value to be added";
-			throw new OneOpsClientAPIException(msg);
-		}
-		
-		RequestSpecification request = createRequest();
-		boolean success = false;
-			ResourceObject ro = new ResourceObject();
-			Map<String ,String> attributes = new HashMap<String ,String>();
-			
-			String uri = transitionEnvUri + environmentName + IConstants.PLATFORM_URI + platformName + IConstants.VARIABLES_URI + variableName;
-			Response response = request.get(uri);
-			if(response != null) {
-				JSONObject var = JsonUtil.createJsonObject(response.getBody().asString());
-				if(var != null && var.has("ciAttributes")) {
-					JSONObject attrs = var.getJSONObject("ciAttributes");
-					 for (Object key : attrs.keySet()) {
-				        //based on you key types
-				        String keyStr = (String)key;
-				        String keyvalue = String.valueOf(attrs.get(keyStr));
+  private static final Logger LOG = LoggerFactory.getLogger(Transition.class);
+  private String transitionEnvUri;
+  private OOInstance instance;
+  private final String assemblyName;
 
-				        attributes.put(keyStr, keyvalue);
-				    }
-					if(isSecure) {
-						attributes.put("secure", "true");
-						attributes.put("encrypted_value", variableValue);
-					} else {
-						attributes.put("secure", "false");
-						attributes.put("value", variableValue);
-					}
-					ro.setAttributes(attributes);
-					
-					JSONObject jsonObject = JsonUtil.createJsonObject(ro , "cms_dj_ci");
-					if(response != null ) {
-						response = request.body(jsonObject.toString()).put(uri);
-						if(response != null) {
-							if(response.getStatusCode() == 200 || response.getStatusCode() == 302) {
-								success = true;
-							} else {
-								String msg = String.format("Failed to get update variables %s due to %s", variableName, response.getStatusLine());
-								throw new OneOpsClientAPIException(msg);
-							}
-						} 
-					}
-				} else {
-					success = true;
-				}
-			} else {
-				String msg = String.format("Failed to get update variables %s due to null response", variableName);
-				throw new OneOpsClientAPIException(msg);
-			}
-			
-		
-		return success;
-	}
-	
-	
+  public Transition(OOInstance instance, String assemblyName) throws OneOpsClientAPIException {
+    super(instance);
+    if (assemblyName == null || assemblyName.length() == 0) {
+      String msg = "Missing assembly name";
+      throw new OneOpsClientAPIException(msg);
+    }
+    this.assemblyName = assemblyName;
+  }
 
-	/**
-	 * List global variables for a given assembly/environment
-	 * 
-	 * @param environmentName
-	 * @return
-	 * @throws OneOpsClientAPIException
-	 */
-	public List<CiResource> listGlobalVariables(String environmentName) throws OneOpsClientAPIException {
-		if(environmentName == null || environmentName.length() == 0) {
-			String msg = "Missing environment name to list enviornment variables";
-			throw new OneOpsClientAPIException(msg);
-		}
-		RequestSpecification request = createRequest();
-		Response response = request.get(transitionEnvUri + environmentName + IConstants.VARIABLES_URI);
-		if(response != null) {
-			if(response.getStatusCode() == 200 || response.getStatusCode() == 302) {
-				return JsonUtil.toObject(response.getBody().asString(), new TypeReference<List<CiResource>>(){});
-			} else {
-				String msg = String.format("Failed to get list of environment variables due to %s", response.getStatusLine());
-				throw new OneOpsClientAPIException(msg);
-			}
-		} 
-		String msg = "Failed to get list of environment variables due to null response";
-		throw new OneOpsClientAPIException(msg);
-	}
-	
-	/**
-	 * Update global variables for a given assembly/environment
-	 * 
-	 * @param environmentName
-	 * @param variables
-	 * @return
-	 * @throws OneOpsClientAPIException
-	 */
-	public Boolean updateGlobalVariable(String environmentName, String variableName, String variableValue, boolean isSecure) throws OneOpsClientAPIException {
-		if(environmentName == null || environmentName.length() == 0) {
-			String msg = "Missing environment name to update component attributes";
-			throw new OneOpsClientAPIException(msg);
-		}
-		if(variableName == null ) {
-			String msg = "Missing variable name to be added";
-			throw new OneOpsClientAPIException(msg);
-		}
-		if(variableValue == null ) {
-			String msg = "Missing variable value to be added";
-			throw new OneOpsClientAPIException(msg);
-		}
-		boolean success = false;
-		RequestSpecification request = createRequest();
-			ResourceObject ro = new ResourceObject();
-			Map<String ,String> attributes = new HashMap<String ,String>();
-			
-			String uri = transitionEnvUri + environmentName + IConstants.VARIABLES_URI + variableName;
-			Response response = request.get(uri);
-			if(response != null) {
-				JSONObject var = JsonUtil.createJsonObject(response.getBody().asString());
-				if(var != null && var.has("ciAttributes")) {
-					JSONObject attrs = var.getJSONObject("ciAttributes");
-					 for (Object key : attrs.keySet()) {
-				        //based on you key types
-				        String keyStr = (String)key;
-				        String keyvalue = String.valueOf(attrs.get(keyStr));
-				        attributes.put(keyStr, keyvalue);
-				    }
-					if(isSecure) {
-						attributes.put("secure", "true");
-						attributes.put("encrypted_value", variableValue);
-					} else {
-						attributes.put("secure", "false");
-						attributes.put("value", variableValue);
-					}
-						
-					ro.setAttributes(attributes);
-					
-					JSONObject jsonObject = JsonUtil.createJsonObject(ro , "cms_dj_ci");
-					response = request.body(jsonObject.toString()).put(uri);
-					if(response != null) {
-						if(response.getStatusCode() == 200 || response.getStatusCode() == 302) {
-							success = true;
-						} else {
-							String msg = String.format("Failed to get update variables %s due to %s", variableName, response.getStatusLine());
-							throw new OneOpsClientAPIException(msg);
-						}
-					} 
-				} else {
-					success = true;
-				}
-			} else {
-				String msg = String.format("Failed to get update variables %s due to null response", variableName);
-				throw new OneOpsClientAPIException(msg);
-			}
-			
-		
-		
-		return success;
-	}
-	
-	/**
-	 * Mark the input {#platformIdList} platforms for delete
-	 * 
-	 * @param environmentName
-	 * @param platformIdList
-	 * @return
-	 * @throws OneOpsClientAPIException
-	 */
-	public CiResource updateDisableEnvironment(String environmentName, List<String> platformIdList) throws OneOpsClientAPIException {
-		if(environmentName == null || environmentName.length() == 0) {
-			String msg = "Missing environment name to disable platforms";
-			throw new OneOpsClientAPIException(msg);
-		}
-		
-		if(platformIdList == null || platformIdList.size() == 0) {
-			String msg = "Missing platforms list to be disabled";
-			throw new OneOpsClientAPIException(msg);
-		}
-		
-		RequestSpecification request = createRequest();
-		JSONObject jsonObject = new JSONObject();
-		jsonObject.put("platformCiIds", platformIdList);
-		
-		Response response = request.body(jsonObject.toString()).put(transitionEnvUri + environmentName + "/disable");
-		if(response != null) {
-			if(response.getStatusCode() == 200 || response.getStatusCode() == 302) {
-				return response.getBody().as(CiResource.class);
-			} else {
-				String msg = String.format("Failed to disable platforms for environment with name %s due to %s", environmentName, response.getStatusLine());
-				throw new OneOpsClientAPIException(msg);
-			}
-		} 
-		String msg = String.format("Failed to disable platforms for environment with name %s due to null response", environmentName);
-		throw new OneOpsClientAPIException(msg);
-	}
-	
-	/**
-	 * Update redundancy configuration for a given platform
-	 * 
-	 * @param environmentName
-	 * @param platformName
-	 * @param config update any 
-	 * @return
-	 * @throws OneOpsClientAPIException
-	 */
-	public Boolean updatePlatformRedundancyConfig(String environmentName, String platformName, String componentName, RedundancyConfig config) throws OneOpsClientAPIException {
-		if(environmentName == null || environmentName.length() == 0) {
-			String msg = "Missing environment name to be updated";
-			throw new OneOpsClientAPIException(msg);
-		}
-		
-		if(platformName == null || platformName.length() == 0) {
-			String msg = "Missing platform name to be updated";
-			throw new OneOpsClientAPIException(msg);
-		}
-		
-		if(config == null ) {
-			String msg = "Missing redundancy config to be updated";
-			throw new OneOpsClientAPIException(msg);
-		}
-		
-		RequestSpecification request = createRequest();
-		
-		JSONObject redundant = new JSONObject();
-		redundant.put("max", config.getMax());
-		redundant.put("pct_dpmt", config.getPercentDeploy());
-		redundant.put("step_down", config.getStepDown());
-		redundant.put("flex", "true");
-		redundant.put("converge", "false");
-		redundant.put("min", config.getMin());
-		redundant.put("current", config.getCurrent());
-		redundant.put("step_up", config.getStepUp());
-		JSONObject rconfig = new JSONObject();
-		rconfig.put("relationAttributes", redundant);
-		
-		redundant = new JSONObject();
-		redundant.put("max", "manifest");
-		redundant.put("pct_dpmt", "manifest");
-		redundant.put("step_down", "manifest");
-		redundant.put("flex", "manifest");
-		redundant.put("converge", "manifest");
-		redundant.put("min", "manifest");
-		redundant.put("current", "manifest");
-		redundant.put("step_up", "manifest");
-		JSONObject owner = new JSONObject();
-		owner.put("owner", redundant);
-		
-		rconfig.put("relationAttrProps", owner);
-		if(componentName == null || componentName.isEmpty()) {
-			componentName = "compute";
-		} 
-		CiResource componentDetails = getPlatformComponent(environmentName, platformName, componentName);
-		JSONObject jo = new JSONObject();
-		jo.put(String.valueOf(componentDetails.getCiId()), rconfig);
-		
-		JSONObject dependsOn = new JSONObject();
-		dependsOn.put("depends_on", jo);
-		
-		Response response = request.body(dependsOn.toString()).put(transitionEnvUri + environmentName + IConstants.PLATFORM_URI + platformName);
-		if(response != null) {
-			if(response.getStatusCode() == 200 || response.getStatusCode() == 302) {
-				return true;
-			} else {
-				String msg = String.format("Failed to update platforms redundancy for environment with name %s due to %s", environmentName, response.getStatusLine());
-				throw new OneOpsClientAPIException(msg);
-			}
-		} 
-		String msg = String.format("Failed to update platforms redundancy for environment with name %s due to null response", environmentName);
-		throw new OneOpsClientAPIException(msg);
-	}
-	
-	public CiResource updatePlatformCloudScale(String environmentName, String platformName, String cloudId, Map<String, String> cloudMap) throws OneOpsClientAPIException {
-		if (environmentName == null || environmentName.length() == 0) {
-			String msg = String.format("Missing environment name to be updated");
-			throw new OneOpsClientAPIException(msg);
-		}
+  @Deprecated
+  public CiResource getEnvironment(String environmentName) throws OneOpsClientAPIException {
+    return super.getEnvironment(assemblyName, environmentName);
+  }
 
-		if (platformName == null || platformName.length() == 0) {
-			String msg = String.format("Missing platform name to be updated");
-			throw new OneOpsClientAPIException(msg);
-		}
+  @Deprecated
+  public List<CiResource> listEnvironments() throws OneOpsClientAPIException {
+    return super.listEnvironments(assemblyName);
+  }
 
-		if (cloudId == null || cloudId.length() == 0) {
-			String msg = String.format("Missing cloud ID to be updated");
-			throw new OneOpsClientAPIException(msg);
-		}
+  @Deprecated
+  public CiResource createEnvironment(String environmentName, String envprofile, Map<String, String> attributes,
+    Map<String, String> platformAvailability, Map<String, Map<String, String>> cloudMap, String description) throws OneOpsClientAPIException {
+    return super.createEnvironment(assemblyName, environmentName, envprofile, attributes, platformAvailability, cloudMap, description);
+  }
 
-		if (cloudMap == null || cloudMap.size() == 0) {
-			String msg = String.format("Missing cloud info to be updated");
-			throw new OneOpsClientAPIException(msg);
-		}
+  @Deprecated
+  public Release commitEnvironment(String environmentName, List<Long> excludePlatforms, String comment) throws OneOpsClientAPIException {
+    return super.commitEnvironment(assemblyName, environmentName, excludePlatforms, comment);
+  }
 
-		RequestSpecification request = createRequest();
-		JSONObject jo = new JSONObject();
-		jo.put("cloud_id", cloudId);
-		jo.put("attributes", cloudMap);
-		Response response = request.body(jo.toString())
-				.put(transitionEnvUri + environmentName + IConstants.PLATFORM_URI + platformName + "/cloud_configuration");
-		if (response != null) {
-			if (response.getStatusCode() == 200 || response.getStatusCode() == 302) {
-				return response.getBody().as(CiResource.class);
-			} else {
-				String msg = String.format("Failed to update platforms cloud scale with cloud id %s due to %s", cloudId,
-						response.getStatusLine());
-				throw new OneOpsClientAPIException(msg);
-			}
-		}
-		String msg = String.format("Failed to update platforms cloud scale with cloud id %s due to null response",
-				cloudId);
-		throw new OneOpsClientAPIException(msg);
-	}
-	
-	
-	
-	/**
-	 * List relays
-	 * 
-	 * @param environmentName
-	 * @return
-	 * @throws OneOpsClientAPIException
-	 */
-	public List<CiResource> listRelays(String environmentName) throws OneOpsClientAPIException {
-		if(environmentName == null || environmentName.length() == 0) {
-			String msg = "Missing environment name to get relays";
-			throw new OneOpsClientAPIException(msg);
-		}
-		
-		RequestSpecification request = createRequest();
-		Response response = request.get(transitionEnvUri + environmentName + "/relays/");
-		if(response != null) {
-			if(response.getStatusCode() == 200 || response.getStatusCode() == 302) {
-				return JsonUtil.toObject(response.getBody().asString(), new TypeReference<List<CiResource>>(){});
-			} else {
-				String msg = String.format("Failed to list relay due to %s", response.getStatusLine());
-				throw new OneOpsClientAPIException(msg);
-			}
-		} 
-		String msg = "Failed to list relay due to null response";
-		throw new OneOpsClientAPIException(msg);
-	}
-	
-	/**
-	 * Get relay details
-	 * 
-	 * @param environmentName
-	 * @param relayName
-	 * @return
-	 * @throws OneOpsClientAPIException
-	 */
-	 
-	public CiResource getRelay(String environmentName, String relayName) throws OneOpsClientAPIException {
-		if(environmentName == null || environmentName.length() == 0) {
-			String msg = "Missing environment name to get relay details";
-			throw new OneOpsClientAPIException(msg);
-		}
-		
-		if(relayName == null || relayName.length() == 0) {
-			String msg = "Missing relay name to fetch details";
-			throw new OneOpsClientAPIException(msg);
-		}
-		
-		RequestSpecification request = createRequest();
-		Response response = request.get(transitionEnvUri + environmentName + "/relays/" + relayName);
-		if(response != null) {
-			if(response.getStatusCode() == 200 || response.getStatusCode() == 302) {
-				return response.getBody().as(CiResource.class);
-			} else {
-				String msg = String.format("Failed to get relay with name %s due to %s", relayName, response.getStatusLine());
-				throw new OneOpsClientAPIException(msg);
-			}
-		} 
-		String msg = String.format("Failed to get relay with name %s due to null response", relayName);
-		throw new OneOpsClientAPIException(msg);
-	}
-	
-	/**
-	 * Add new Relay
-	 * 
-	 * @param relayName
-	 * @param severity
-	 * @param emails
-	 * @param source
-	 * @param nsPaths
-	 * @param regex
-	 * @param correlation
-	 * @return
-	 * @throws OneOpsClientAPIException
-	 */
-	public CiResource addRelay(String environmentName, String relayName, String severity, String emails, String source, String nsPaths, String regex, boolean correlation) throws OneOpsClientAPIException {
-		if(environmentName == null || environmentName.length() == 0) {
-			String msg = "Missing environment name to create relay";
-			throw new OneOpsClientAPIException(msg);
-		}
-		
-		ResourceObject ro = new ResourceObject();
-		Map<String ,String> properties= Maps.newHashMap();
-		
-		if(relayName == null || relayName.length() == 0) {
-			String msg = "Missing relay name to create one";
-			throw new OneOpsClientAPIException(msg);
-		} 
-		if(emails == null || emails.length() == 0) {
-			String msg = "Missing emails addresses to create relay";
-			throw new OneOpsClientAPIException(msg);
-		} 
-		if(severity == null || severity.length() == 0) {
-			String msg = "Missing severity to create relay";
-			throw new OneOpsClientAPIException(msg);
-		} 
-		if(source == null || source.length() == 0) {
-			String msg = "Missing source to create relay";
-			throw new OneOpsClientAPIException(msg);
-		} 
-		
+  @Deprecated
+  public Deployment deploy(String environmentName, String comments) throws OneOpsClientAPIException {
+    return super.deploy(assemblyName, environmentName, comments);
+  }
 
-		properties.put("ciName", relayName);
-		String path = "/" + instance.getOrgname() + "/" + assemblyName + "/" + environmentName;
-		properties.put("nsPath", path );
-		
-		RequestSpecification request = createRequest();
-		ro.setProperties(properties);
-		
-		Response newRelayResponse = request.get(transitionEnvUri + environmentName + "/relays/new");
-		if(newRelayResponse != null) {
-			JsonPath attachmentDetails = newRelayResponse.getBody().jsonPath();
-			Map<String, String> attributes = attachmentDetails.getMap("ciAttributes");
-			if(attributes == null) {
-				attributes = Maps.newHashMap();
-			}
-			attributes.put("enabled", "true");
-			attributes.put("emails", emails);
-			if(!Strings.isNullOrEmpty(severity))
-				attributes.put("severity", severity);
-			if(!Strings.isNullOrEmpty(source))
-				attributes.put("source", source);
-			if(!Strings.isNullOrEmpty(nsPaths))
-				attributes.put("ns_paths", nsPaths);
-			if(!Strings.isNullOrEmpty(regex))
-				attributes.put("text_regex", regex);
-			
-			attributes.put("correlation", String.valueOf(correlation));
-			ro.setAttributes(attributes);
-		}
-		
-		JSONObject jsonObject = JsonUtil.createJsonObject(ro , "cms_ci");
-		Response response = request.body(jsonObject.toString()).post(transitionEnvUri + environmentName + "/relays");
-		
-		if(response != null) {
-			if(response.getStatusCode() == 200 || response.getStatusCode() == 302) {
-				return response.getBody().as(CiResource.class);
-			} else {
-				String msg = String.format("Failed to create relay with name %s due to %s", relayName, response.getStatusLine());
-				throw new OneOpsClientAPIException(msg);
-			}
-		} 
-		String msg = String.format("Failed to create relay with name %s due to null response", relayName);
-		throw new OneOpsClientAPIException(msg);
-	}
-	
-	/**
-	 * Update relay
-	 * 
-	 * @param environmentName
-	 * @param relayName
-	 * @param severity
-	 * @param emails
-	 * @param source
-	 * @param nsPaths
-	 * @param regex
-	 * @param correlation
-	 * @param enable
-	 * @return
-	 * @throws OneOpsClientAPIException
-	 */
-	public CiResource updateRelay(String environmentName, String relayName, String severity, String emails, String source, String nsPaths, String regex, boolean correlation, boolean enable) throws OneOpsClientAPIException {
-		if(environmentName == null || environmentName.length() == 0) {
-			String msg = "Missing environment name to create relay";
-			throw new OneOpsClientAPIException(msg);
-		}
-		
-		ResourceObject ro = new ResourceObject();
-		Map<String ,String> attributes = Maps.newHashMap();
-		
-		if(relayName == null || relayName.length() == 0) {
-			String msg = "Missing relay name to update";
-			throw new OneOpsClientAPIException(msg);
-		} 
-		
-		RequestSpecification request = createRequest();
-		
-		Response relayResponse = request.get(transitionEnvUri + environmentName + "/relays/" + relayName);
-		if(relayResponse != null) {
-			JsonPath newVarJsonPath = relayResponse.getBody().jsonPath();
-			if(newVarJsonPath != null) {
-				attributes = newVarJsonPath.getMap("ciAttributes");
-				if(attributes == null) {
-					attributes = Maps.newHashMap();
-				} else {
-					attributes.put("enabled", String.valueOf(enable));
-					if(!Strings.isNullOrEmpty(emails))
-						attributes.put("emails", emails);
-					if(!Strings.isNullOrEmpty(severity))
-						attributes.put("severity", severity);
-					if(!Strings.isNullOrEmpty(source))
-						attributes.put("source", source);
-					if(!Strings.isNullOrEmpty(nsPaths))
-						attributes.put("ns_paths", nsPaths);
-					if(!Strings.isNullOrEmpty(regex))
-						attributes.put("text_regex", regex);
-				}
-			}
-		}
-		ro.setAttributes(attributes);
-		
-		JSONObject jsonObject = JsonUtil.createJsonObject(ro , "cms_ci");
-		
-		Response response = request.body(jsonObject.toString()).put(transitionEnvUri + environmentName + "/relays/" + relayName);
-		
-		if(response != null) {
-			if(response.getStatusCode() == 200 || response.getStatusCode() == 302) {
-				return response.getBody().as(CiResource.class);
-			} else {
-				String msg = String.format("Failed to update relay with name %s due to %s", relayName, response.getStatusLine());
-				throw new OneOpsClientAPIException(msg);
-			}
-		} 
-		String msg = String.format("Failed to update relay with name %s due to null response", relayName);
-		throw new OneOpsClientAPIException(msg);
-	}
+  @Deprecated
+  public Deployment getDeploymentStatus(String environmentName, Long deploymentId) throws OneOpsClientAPIException {
+    return super.getDeploymentStatus(assemblyName, environmentName, deploymentId);
+  }
+
+  @Deprecated
+  public Deployment getLatestDeployment(String environmentName) throws OneOpsClientAPIException {
+    return super.getLatestDeployment(assemblyName, environmentName);
+  }
+
+  @Deprecated
+  public Release discardDeploymentPlan(String environmentName) throws OneOpsClientAPIException {
+    return super.discardDeploymentPlan(assemblyName, environmentName);
+  }
+
+  @Deprecated
+  public Release discardOpenRelease(String environmentName) throws OneOpsClientAPIException {
+    return super.discardOpenRelease(assemblyName, environmentName);
+  }
+
+  @Deprecated
+  public CiResource disableAllPlatforms(String environmentName) throws OneOpsClientAPIException {
+    return super.disableAllPlatforms(assemblyName, environmentName);
+  }
+
+  @Deprecated
+  public Release getLatestRelease(String environmentName) throws OneOpsClientAPIException {
+    return super.getLatestRelease(assemblyName, environmentName);
+  }
+
+  @Deprecated
+  public Release getBomRelease(String environmentName) throws OneOpsClientAPIException {
+    return super.getBomRelease(assemblyName, environmentName);
+  }
+
+  @Deprecated
+  public Deployment cancelDeployment(String environmentName, Long deploymentId, Long releaseId) throws OneOpsClientAPIException {
+    return super.cancelDeployment(assemblyName, environmentName, deploymentId, releaseId);
+  }
+
+  @Deprecated
+  public DeploymentRFC getDeployment(String environmentName, Long deploymentId) throws OneOpsClientAPIException {
+    return super.getDeployment(assemblyName, environmentName, deploymentId);
+  }
+
+  @Deprecated
+  public Log getDeploymentRfcLog(String environmentName, Long deploymentId, Long rfcId) throws OneOpsClientAPIException {
+    return super.getDeploymentRfcLog(assemblyName, environmentName, deploymentId, rfcId);
+  }
+
+  @Deprecated
+  public Deployment approveDeployment(String environmentName, Long deploymentId, Long releaseId) throws OneOpsClientAPIException {
+    return super.approveDeployment(assemblyName, environmentName, deploymentId, releaseId);
+  }
+
+  @Deprecated
+  public Deployment retryDeployment(String environmentName, Long deploymentId, Long releaseId) throws OneOpsClientAPIException {
+    return super.updateDeploymentStatus(assemblyName, environmentName, deploymentId, releaseId, "active");
+  }
+
+  @Deprecated
+  private Deployment updateDeploymentStatus(String environmentName, Long deploymentId, Long releaseId, String newstate) throws OneOpsClientAPIException {
+    return super.updateDeploymentStatus(assemblyName, environmentName, deploymentId, releaseId, newstate);
+  }
+
+  @Deprecated
+  public CiResource deleteEnvironment(String environmentName) throws OneOpsClientAPIException {
+    return super.deleteEnvironment(assemblyName, environmentName);
+  }
+
+  @Deprecated
+  public List<CiResource> listPlatforms(String environmentName) throws OneOpsClientAPIException {
+    return super.listPlatforms(assemblyName, environmentName);
+  }
+
+  @Deprecated
+  public CiResource getPlatform(String environmentName, String platformName) throws OneOpsClientAPIException {
+    return super.getPlatformComponent(assemblyName, environmentName, platformName);
+  }
+
+  @Deprecated
+  public List<CiResource> listPlatformComponents(String environmentName, String platformName) throws OneOpsClientAPIException {
+    return super.listPlatformComponents(assemblyName, environmentName, platformName);
+  }
+
+  @Deprecated
+  public CiResource getPlatformComponent(String environmentName, String platformName, String componentName) throws OneOpsClientAPIException {
+    return super.getPlatformComponent(assemblyName, environmentName, platformName, componentName);
+  }
+
+  @Deprecated
+  public CiResource updatePlatformComponent(String environmentName, String platformName, String componentName, Map<String, String> attributes) throws OneOpsClientAPIException {
+    return super.updatePlatformComponent(assemblyName, environmentName, platformName, componentName, attributes);
+  }
+
+  @Deprecated
+  public CiResource touchPlatformComponent(String environmentName, String platformName, String componentName) throws OneOpsClientAPIException {
+    return super.touchPlatformComponent(assemblyName, environmentName, platformName, componentName);
+  }
+
+  @Deprecated
+  public CiResource pullDesign(String environmentName) throws OneOpsClientAPIException {
+    return super.pullDesign(assemblyName, environmentName);
+  }
+
+  @Deprecated
+  public CiResource pullNewPlatform(String environmentName, Map<String, String> platformAvailability) throws OneOpsClientAPIException {
+    return super.pullNewPlatform(assemblyName, environmentName, platformAvailability);
+  }
+
+  @Deprecated
+  public List<CiResource> listPlatformVariables(String environmentName, String platformName) throws OneOpsClientAPIException {
+    return super.listPlatformVariables(assemblyName, platformName);
+  }
+
+  @Deprecated
+  public Boolean updatePlatformVariable(String environmentName, String platformName, String variableName, String variableValue, boolean isSecure) throws OneOpsClientAPIException {
+    return super.updatePlatformVariable(assemblyName, platformName, variableName, variableValue, isSecure);
+  }
+
+  @Deprecated
+  public List<CiResource> listGlobalVariables(String environmentName) throws OneOpsClientAPIException {
+    return super.listGlobalVariables(assemblyName, environmentName);
+  }
+
+  @Deprecated
+  public Boolean updateGlobalVariable(String environmentName, String variableName, String variableValue, boolean isSecure) throws OneOpsClientAPIException {
+    return super.updateGlobalVariable(assemblyName, environmentName, variableName, variableValue, isSecure);
+  }
+
+  @Deprecated
+  public CiResource updateDisableEnvironment(String environmentName, List<String> platformIdList) throws OneOpsClientAPIException {
+    return super.updateDisableEnvironment(assemblyName, environmentName, platformIdList);
+  }
+
+  @Deprecated
+  public Boolean updatePlatformRedundancyConfig(String environmentName, String platformName, String componentName, RedundancyConfig config) throws OneOpsClientAPIException {
+    return super.updatePlatformRedundancyConfig(assemblyName, environmentName, platformName, componentName, config);
+  }
+
+  @Deprecated
+  public CiResource updatePlatformCloudScale(String environmentName, String platformName, String cloudId, Map<String, String> cloudMap) throws OneOpsClientAPIException {
+    return super.updatePlatformCloudScale(assemblyName, environmentName, platformName, cloudId, cloudMap);
+  }
+
+  public List<CiResource> listRelays(String environmentName) throws OneOpsClientAPIException {
+    return super.listRelays(assemblyName, environmentName);
+  }
+
+  @Deprecated
+  public CiResource getRelay(String environmentName, String relayName) throws OneOpsClientAPIException {
+    return super.getRelay(assemblyName, environmentName, relayName);
+  }
+
+  @Deprecated
+  public CiResource addRelay(String environmentName, String relayName, String severity, String emails, String source, String nsPaths, String regex, boolean correlation)
+    throws OneOpsClientAPIException {
+    return super.addRelay(assemblyName, environmentName, relayName, severity, emails, source, nsPaths, regex, correlation);
+  }
+
+  @Deprecated
+  public CiResource updateRelay(String environmentName, String relayName, String severity, String emails, String source, String nsPaths, String regex, boolean correlation, boolean enable)
+    throws OneOpsClientAPIException {
+    return super.updateRelay(assemblyName, environmentName, relayName, severity, emails, source, nsPaths, regex, correlation, enable);
+  }
 }

--- a/src/main/java/com/oneops/api/resource/model/Action.java
+++ b/src/main/java/com/oneops/api/resource/model/Action.java
@@ -2,6 +2,7 @@ package com.oneops.api.resource.model;
 
 import java.util.HashMap;
 import java.util.Map;
+
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
 import com.fasterxml.jackson.annotation.JsonIgnore;
@@ -10,177 +11,177 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
-@JsonPropertyOrder({ "actionId", "actionName", "ciId", "actionState", "execOrder", "isCritical", "extraInfo", "arglist",
-		"payLoadDef", "createdBy", "created", "updated", "procedureId" })
+@JsonPropertyOrder({"actionId", "actionName", "ciId", "actionState", "execOrder", "isCritical", "extraInfo", "arglist",
+    "payLoadDef", "createdBy", "created", "updated", "procedureId"})
 public class Action {
 
-	@JsonProperty("actionId")
-	private Long actionId;
-	@JsonProperty("actionName")
-	private String actionName;
-	@JsonProperty("ciId")
-	private Long ciId;
-	@JsonProperty("actionState")
-	private String actionState;
-	@JsonProperty("execOrder")
-	private Long execOrder;
-	@JsonProperty("isCritical")
-	private Boolean isCritical;
-	@JsonProperty("extraInfo")
-	private Object extraInfo;
-	@JsonProperty("arglist")
-	private String arglist;
-	@JsonProperty("payLoadDef")
-	private Object payLoadDef;
-	@JsonProperty("createdBy")
-	private Object createdBy;
-	@JsonProperty("created")
-	private Long created;
-	@JsonProperty("updated")
-	private Long updated;
-	@JsonProperty("procedureId")
-	private Long procedureId;
-	@JsonIgnore
-	private Map<String, Object> additionalProperties = new HashMap<String, Object>();
+  @JsonProperty("actionId")
+  private Long actionId;
+  @JsonProperty("actionName")
+  private String actionName;
+  @JsonProperty("ciId")
+  private Long ciId;
+  @JsonProperty("actionState")
+  private String actionState;
+  @JsonProperty("execOrder")
+  private Long execOrder;
+  @JsonProperty("isCritical")
+  private Boolean isCritical;
+  @JsonProperty("extraInfo")
+  private Object extraInfo;
+  @JsonProperty("arglist")
+  private String arglist;
+  @JsonProperty("payLoadDef")
+  private Object payLoadDef;
+  @JsonProperty("createdBy")
+  private Object createdBy;
+  @JsonProperty("created")
+  private Long created;
+  @JsonProperty("updated")
+  private Long updated;
+  @JsonProperty("procedureId")
+  private Long procedureId;
+  @JsonIgnore
+  private Map<String, Object> additionalProperties = new HashMap<String, Object>();
 
-	@JsonProperty("actionId")
-	public Long getActionId() {
-		return actionId;
-	}
+  @JsonProperty("actionId")
+  public Long getActionId() {
+    return actionId;
+  }
 
-	@JsonProperty("actionId")
-	public void setActionId(Long actionId) {
-		this.actionId = actionId;
-	}
+  @JsonProperty("actionId")
+  public void setActionId(Long actionId) {
+    this.actionId = actionId;
+  }
 
-	@JsonProperty("actionName")
-	public String getActionName() {
-		return actionName;
-	}
+  @JsonProperty("actionName")
+  public String getActionName() {
+    return actionName;
+  }
 
-	@JsonProperty("actionName")
-	public void setActionName(String actionName) {
-		this.actionName = actionName;
-	}
+  @JsonProperty("actionName")
+  public void setActionName(String actionName) {
+    this.actionName = actionName;
+  }
 
-	@JsonProperty("ciId")
-	public Long getCiId() {
-		return ciId;
-	}
+  @JsonProperty("ciId")
+  public Long getCiId() {
+    return ciId;
+  }
 
-	@JsonProperty("ciId")
-	public void setCiId(Long ciId) {
-		this.ciId = ciId;
-	}
+  @JsonProperty("ciId")
+  public void setCiId(Long ciId) {
+    this.ciId = ciId;
+  }
 
-	@JsonProperty("actionState")
-	public String getActionState() {
-		return actionState;
-	}
+  @JsonProperty("actionState")
+  public String getActionState() {
+    return actionState;
+  }
 
-	@JsonProperty("actionState")
-	public void setActionState(String actionState) {
-		this.actionState = actionState;
-	}
+  @JsonProperty("actionState")
+  public void setActionState(String actionState) {
+    this.actionState = actionState;
+  }
 
-	@JsonProperty("execOrder")
-	public Long getExecOrder() {
-		return execOrder;
-	}
+  @JsonProperty("execOrder")
+  public Long getExecOrder() {
+    return execOrder;
+  }
 
-	@JsonProperty("execOrder")
-	public void setExecOrder(Long execOrder) {
-		this.execOrder = execOrder;
-	}
+  @JsonProperty("execOrder")
+  public void setExecOrder(Long execOrder) {
+    this.execOrder = execOrder;
+  }
 
-	@JsonProperty("isCritical")
-	public Boolean getIsCritical() {
-		return isCritical;
-	}
+  @JsonProperty("isCritical")
+  public Boolean getIsCritical() {
+    return isCritical;
+  }
 
-	@JsonProperty("isCritical")
-	public void setIsCritical(Boolean isCritical) {
-		this.isCritical = isCritical;
-	}
+  @JsonProperty("isCritical")
+  public void setIsCritical(Boolean isCritical) {
+    this.isCritical = isCritical;
+  }
 
-	@JsonProperty("extraInfo")
-	public Object getExtraInfo() {
-		return extraInfo;
-	}
+  @JsonProperty("extraInfo")
+  public Object getExtraInfo() {
+    return extraInfo;
+  }
 
-	@JsonProperty("extraInfo")
-	public void setExtraInfo(Object extraInfo) {
-		this.extraInfo = extraInfo;
-	}
+  @JsonProperty("extraInfo")
+  public void setExtraInfo(Object extraInfo) {
+    this.extraInfo = extraInfo;
+  }
 
-	@JsonProperty("arglist")
-	public String getArglist() {
-		return arglist;
-	}
+  @JsonProperty("arglist")
+  public String getArglist() {
+    return arglist;
+  }
 
-	@JsonProperty("arglist")
-	public void setArglist(String arglist) {
-		this.arglist = arglist;
-	}
+  @JsonProperty("arglist")
+  public void setArglist(String arglist) {
+    this.arglist = arglist;
+  }
 
-	@JsonProperty("payLoadDef")
-	public Object getPayLoadDef() {
-		return payLoadDef;
-	}
+  @JsonProperty("payLoadDef")
+  public Object getPayLoadDef() {
+    return payLoadDef;
+  }
 
-	@JsonProperty("payLoadDef")
-	public void setPayLoadDef(Object payLoadDef) {
-		this.payLoadDef = payLoadDef;
-	}
+  @JsonProperty("payLoadDef")
+  public void setPayLoadDef(Object payLoadDef) {
+    this.payLoadDef = payLoadDef;
+  }
 
-	@JsonProperty("createdBy")
-	public Object getCreatedBy() {
-		return createdBy;
-	}
+  @JsonProperty("createdBy")
+  public Object getCreatedBy() {
+    return createdBy;
+  }
 
-	@JsonProperty("createdBy")
-	public void setCreatedBy(Object createdBy) {
-		this.createdBy = createdBy;
-	}
+  @JsonProperty("createdBy")
+  public void setCreatedBy(Object createdBy) {
+    this.createdBy = createdBy;
+  }
 
-	@JsonProperty("created")
-	public Long getCreated() {
-		return created;
-	}
+  @JsonProperty("created")
+  public Long getCreated() {
+    return created;
+  }
 
-	@JsonProperty("created")
-	public void setCreated(Long created) {
-		this.created = created;
-	}
+  @JsonProperty("created")
+  public void setCreated(Long created) {
+    this.created = created;
+  }
 
-	@JsonProperty("updated")
-	public Long getUpdated() {
-		return updated;
-	}
+  @JsonProperty("updated")
+  public Long getUpdated() {
+    return updated;
+  }
 
-	@JsonProperty("updated")
-	public void setUpdated(Long updated) {
-		this.updated = updated;
-	}
+  @JsonProperty("updated")
+  public void setUpdated(Long updated) {
+    this.updated = updated;
+  }
 
-	@JsonProperty("procedureId")
-	public Long getProcedureId() {
-		return procedureId;
-	}
+  @JsonProperty("procedureId")
+  public Long getProcedureId() {
+    return procedureId;
+  }
 
-	@JsonProperty("procedureId")
-	public void setProcedureId(Long procedureId) {
-		this.procedureId = procedureId;
-	}
+  @JsonProperty("procedureId")
+  public void setProcedureId(Long procedureId) {
+    this.procedureId = procedureId;
+  }
 
-	@JsonAnyGetter
-	public Map<String, Object> getAdditionalProperties() {
-		return this.additionalProperties;
-	}
+  @JsonAnyGetter
+  public Map<String, Object> getAdditionalProperties() {
+    return this.additionalProperties;
+  }
 
-	@JsonAnySetter
-	public void setAdditionalProperty(String name, Object value) {
-		this.additionalProperties.put(name, value);
-	}
+  @JsonAnySetter
+  public void setAdditionalProperty(String name, Object value) {
+    this.additionalProperties.put(name, value);
+  }
 
 }

--- a/src/main/java/com/oneops/api/resource/model/AttrProps.java
+++ b/src/main/java/com/oneops/api/resource/model/AttrProps.java
@@ -2,6 +2,7 @@ package com.oneops.api.resource.model;
 
 import java.util.HashMap;
 import java.util.Map;
+
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
 import com.fasterxml.jackson.annotation.JsonIgnore;
@@ -14,17 +15,17 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 })
 public class AttrProps {
 
-	@JsonIgnore
-	private Map<String, Object> additionalProperties = new HashMap<String, Object>();
+  @JsonIgnore
+  private Map<String, Object> additionalProperties = new HashMap<String, Object>();
 
-	@JsonAnyGetter
-	public Map<String, Object> getAdditionalProperties() {
-		return this.additionalProperties;
-	}
+  @JsonAnyGetter
+  public Map<String, Object> getAdditionalProperties() {
+    return this.additionalProperties;
+  }
 
-	@JsonAnySetter
-	public void setAdditionalProperty(String name, Object value) {
-		this.additionalProperties.put(name, value);
-	}
+  @JsonAnySetter
+  public void setAdditionalProperty(String name, Object value) {
+    this.additionalProperties.put(name, value);
+  }
 
 }

--- a/src/main/java/com/oneops/api/resource/model/CiAttributes.java
+++ b/src/main/java/com/oneops/api/resource/model/CiAttributes.java
@@ -2,6 +2,7 @@ package com.oneops.api.resource.model;
 
 import java.util.HashMap;
 import java.util.Map;
+
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
 import com.fasterxml.jackson.annotation.JsonIgnore;
@@ -10,68 +11,68 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
-@JsonPropertyOrder({ "adminstatus", "auth", "description", "location" })
+@JsonPropertyOrder({"adminstatus", "auth", "description", "location"})
 public class CiAttributes {
 
-	@JsonProperty("adminstatus")
-	private String adminstatus;
-	@JsonProperty("auth")
-	private Object auth;
-	@JsonProperty("description")
-	private String description;
-	@JsonProperty("location")
-	private String location;
-	@JsonIgnore
-	private Map<String, Object> additionalProperties = new HashMap<String, Object>();
+  @JsonProperty("adminstatus")
+  private String adminstatus;
+  @JsonProperty("auth")
+  private Object auth;
+  @JsonProperty("description")
+  private String description;
+  @JsonProperty("location")
+  private String location;
+  @JsonIgnore
+  private Map<String, Object> additionalProperties = new HashMap<String, Object>();
 
-	@JsonProperty("adminstatus")
-	public String getAdminstatus() {
-		return adminstatus;
-	}
+  @JsonProperty("adminstatus")
+  public String getAdminstatus() {
+    return adminstatus;
+  }
 
-	@JsonProperty("adminstatus")
-	public void setAdminstatus(String adminstatus) {
-		this.adminstatus = adminstatus;
-	}
+  @JsonProperty("adminstatus")
+  public void setAdminstatus(String adminstatus) {
+    this.adminstatus = adminstatus;
+  }
 
-	@JsonProperty("auth")
-	public Object getAuth() {
-		return auth;
-	}
+  @JsonProperty("auth")
+  public Object getAuth() {
+    return auth;
+  }
 
-	@JsonProperty("auth")
-	public void setAuth(Object auth) {
-		this.auth = auth;
-	}
+  @JsonProperty("auth")
+  public void setAuth(Object auth) {
+    this.auth = auth;
+  }
 
-	@JsonProperty("description")
-	public String getDescription() {
-		return description;
-	}
+  @JsonProperty("description")
+  public String getDescription() {
+    return description;
+  }
 
-	@JsonProperty("description")
-	public void setDescription(String description) {
-		this.description = description;
-	}
+  @JsonProperty("description")
+  public void setDescription(String description) {
+    this.description = description;
+  }
 
-	@JsonProperty("location")
-	public String getLocation() {
-		return location;
-	}
+  @JsonProperty("location")
+  public String getLocation() {
+    return location;
+  }
 
-	@JsonProperty("location")
-	public void setLocation(String location) {
-		this.location = location;
-	}
+  @JsonProperty("location")
+  public void setLocation(String location) {
+    this.location = location;
+  }
 
-	@JsonAnyGetter
-	public Map<String, Object> getAdditionalProperties() {
-		return this.additionalProperties;
-	}
+  @JsonAnyGetter
+  public Map<String, Object> getAdditionalProperties() {
+    return this.additionalProperties;
+  }
 
-	@JsonAnySetter
-	public void setAdditionalProperty(String name, Object value) {
-		this.additionalProperties.put(name, value);
-	}
+  @JsonAnySetter
+  public void setAdditionalProperty(String name, Object value) {
+    this.additionalProperties.put(name, value);
+  }
 
 }

--- a/src/main/java/com/oneops/api/resource/model/CiResource.java
+++ b/src/main/java/com/oneops/api/resource/model/CiResource.java
@@ -2,6 +2,7 @@ package com.oneops.api.resource.model;
 
 import java.util.HashMap;
 import java.util.Map;
+
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
 import com.fasterxml.jackson.annotation.JsonIgnore;
@@ -10,213 +11,213 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
-@JsonPropertyOrder({ "ciId", "ciName", "ciClassName", "impl", "nsPath", "ciGoid", "comments", "ciState",
-		"lastAppliedRfcId", "createdBy", "updatedBy", "created", "updated", "nsId", "ciAttributes", "attrProps" })
+@JsonPropertyOrder({"ciId", "ciName", "ciClassName", "impl", "nsPath", "ciGoid", "comments", "ciState",
+    "lastAppliedRfcId", "createdBy", "updatedBy", "created", "updated", "nsId", "ciAttributes", "attrProps"})
 public class CiResource {
 
-	@JsonProperty("ciId")
-	private Long ciId;
-	@JsonProperty("ciName")
-	private String ciName;
-	@JsonProperty("ciClassName")
-	private String ciClassName;
-	@JsonProperty("impl")
-	private String impl;
-	@JsonProperty("nsPath")
-	private String nsPath;
-	@JsonProperty("ciGoid")
-	private String ciGoid;
-	@JsonProperty("comments")
-	private String comments;
-	@JsonProperty("ciState")
-	private String ciState;
-	@JsonProperty("lastAppliedRfcId")
-	private Long lastAppliedRfcId;
-	@JsonProperty("createdBy")
-	private String createdBy;
-	@JsonProperty("updatedBy")
-	private Object updatedBy;
-	@JsonProperty("created")
-	private Long created;
-	@JsonProperty("updated")
-	private Long updated;
-	@JsonProperty("nsId")
-	private Long nsId;
-	@JsonProperty("ciAttributes")
-	private CiAttributes ciAttributes;
-	@JsonProperty("ciAttrProps")
-	private AttrProps attrProps;
-	@JsonIgnore
-	private Map<String, Object> additionalProperties = new HashMap<String, Object>();
+  @JsonProperty("ciId")
+  private Long ciId;
+  @JsonProperty("ciName")
+  private String ciName;
+  @JsonProperty("ciClassName")
+  private String ciClassName;
+  @JsonProperty("impl")
+  private String impl;
+  @JsonProperty("nsPath")
+  private String nsPath;
+  @JsonProperty("ciGoid")
+  private String ciGoid;
+  @JsonProperty("comments")
+  private String comments;
+  @JsonProperty("ciState")
+  private String ciState;
+  @JsonProperty("lastAppliedRfcId")
+  private Long lastAppliedRfcId;
+  @JsonProperty("createdBy")
+  private String createdBy;
+  @JsonProperty("updatedBy")
+  private Object updatedBy;
+  @JsonProperty("created")
+  private Long created;
+  @JsonProperty("updated")
+  private Long updated;
+  @JsonProperty("nsId")
+  private Long nsId;
+  @JsonProperty("ciAttributes")
+  private CiAttributes ciAttributes;
+  @JsonProperty("ciAttrProps")
+  private AttrProps attrProps;
+  @JsonIgnore
+  private Map<String, Object> additionalProperties = new HashMap<String, Object>();
 
-	@JsonProperty("ciId")
-	public Long getCiId() {
-		return ciId;
-	}
+  @JsonProperty("ciId")
+  public Long getCiId() {
+    return ciId;
+  }
 
-	@JsonProperty("ciId")
-	public void setCiId(Long ciId) {
-		this.ciId = ciId;
-	}
+  @JsonProperty("ciId")
+  public void setCiId(Long ciId) {
+    this.ciId = ciId;
+  }
 
-	@JsonProperty("ciName")
-	public String getCiName() {
-		return ciName;
-	}
+  @JsonProperty("ciName")
+  public String getCiName() {
+    return ciName;
+  }
 
-	@JsonProperty("ciName")
-	public void setCiName(String ciName) {
-		this.ciName = ciName;
-	}
+  @JsonProperty("ciName")
+  public void setCiName(String ciName) {
+    this.ciName = ciName;
+  }
 
-	@JsonProperty("ciClassName")
-	public String getCiClassName() {
-		return ciClassName;
-	}
+  @JsonProperty("ciClassName")
+  public String getCiClassName() {
+    return ciClassName;
+  }
 
-	@JsonProperty("ciClassName")
-	public void setCiClassName(String ciClassName) {
-		this.ciClassName = ciClassName;
-	}
+  @JsonProperty("ciClassName")
+  public void setCiClassName(String ciClassName) {
+    this.ciClassName = ciClassName;
+  }
 
-	@JsonProperty("impl")
-	public String getImpl() {
-		return impl;
-	}
+  @JsonProperty("impl")
+  public String getImpl() {
+    return impl;
+  }
 
-	@JsonProperty("impl")
-	public void setImpl(String impl) {
-		this.impl = impl;
-	}
+  @JsonProperty("impl")
+  public void setImpl(String impl) {
+    this.impl = impl;
+  }
 
-	@JsonProperty("nsPath")
-	public String getNsPath() {
-		return nsPath;
-	}
+  @JsonProperty("nsPath")
+  public String getNsPath() {
+    return nsPath;
+  }
 
-	@JsonProperty("nsPath")
-	public void setNsPath(String nsPath) {
-		this.nsPath = nsPath;
-	}
+  @JsonProperty("nsPath")
+  public void setNsPath(String nsPath) {
+    this.nsPath = nsPath;
+  }
 
-	@JsonProperty("ciGoid")
-	public String getCiGoid() {
-		return ciGoid;
-	}
+  @JsonProperty("ciGoid")
+  public String getCiGoid() {
+    return ciGoid;
+  }
 
-	@JsonProperty("ciGoid")
-	public void setCiGoid(String ciGoid) {
-		this.ciGoid = ciGoid;
-	}
+  @JsonProperty("ciGoid")
+  public void setCiGoid(String ciGoid) {
+    this.ciGoid = ciGoid;
+  }
 
-	@JsonProperty("comments")
-	public String getComments() {
-		return comments;
-	}
+  @JsonProperty("comments")
+  public String getComments() {
+    return comments;
+  }
 
-	@JsonProperty("comments")
-	public void setComments(String comments) {
-		this.comments = comments;
-	}
+  @JsonProperty("comments")
+  public void setComments(String comments) {
+    this.comments = comments;
+  }
 
-	@JsonProperty("ciState")
-	public String getCiState() {
-		return ciState;
-	}
+  @JsonProperty("ciState")
+  public String getCiState() {
+    return ciState;
+  }
 
-	@JsonProperty("ciState")
-	public void setCiState(String ciState) {
-		this.ciState = ciState;
-	}
+  @JsonProperty("ciState")
+  public void setCiState(String ciState) {
+    this.ciState = ciState;
+  }
 
-	@JsonProperty("lastAppliedRfcId")
-	public Long getLastAppliedRfcId() {
-		return lastAppliedRfcId;
-	}
+  @JsonProperty("lastAppliedRfcId")
+  public Long getLastAppliedRfcId() {
+    return lastAppliedRfcId;
+  }
 
-	@JsonProperty("lastAppliedRfcId")
-	public void setLastAppliedRfcId(Long lastAppliedRfcId) {
-		this.lastAppliedRfcId = lastAppliedRfcId;
-	}
+  @JsonProperty("lastAppliedRfcId")
+  public void setLastAppliedRfcId(Long lastAppliedRfcId) {
+    this.lastAppliedRfcId = lastAppliedRfcId;
+  }
 
-	@JsonProperty("createdBy")
-	public String getCreatedBy() {
-		return createdBy;
-	}
+  @JsonProperty("createdBy")
+  public String getCreatedBy() {
+    return createdBy;
+  }
 
-	@JsonProperty("createdBy")
-	public void setCreatedBy(String createdBy) {
-		this.createdBy = createdBy;
-	}
+  @JsonProperty("createdBy")
+  public void setCreatedBy(String createdBy) {
+    this.createdBy = createdBy;
+  }
 
-	@JsonProperty("updatedBy")
-	public Object getUpdatedBy() {
-		return updatedBy;
-	}
+  @JsonProperty("updatedBy")
+  public Object getUpdatedBy() {
+    return updatedBy;
+  }
 
-	@JsonProperty("updatedBy")
-	public void setUpdatedBy(Object updatedBy) {
-		this.updatedBy = updatedBy;
-	}
+  @JsonProperty("updatedBy")
+  public void setUpdatedBy(Object updatedBy) {
+    this.updatedBy = updatedBy;
+  }
 
-	@JsonProperty("created")
-	public Long getCreated() {
-		return created;
-	}
+  @JsonProperty("created")
+  public Long getCreated() {
+    return created;
+  }
 
-	@JsonProperty("created")
-	public void setCreated(Long created) {
-		this.created = created;
-	}
+  @JsonProperty("created")
+  public void setCreated(Long created) {
+    this.created = created;
+  }
 
-	@JsonProperty("updated")
-	public Long getUpdated() {
-		return updated;
-	}
+  @JsonProperty("updated")
+  public Long getUpdated() {
+    return updated;
+  }
 
-	@JsonProperty("updated")
-	public void setUpdated(Long updated) {
-		this.updated = updated;
-	}
+  @JsonProperty("updated")
+  public void setUpdated(Long updated) {
+    this.updated = updated;
+  }
 
-	@JsonProperty("nsId")
-	public Long getNsId() {
-		return nsId;
-	}
+  @JsonProperty("nsId")
+  public Long getNsId() {
+    return nsId;
+  }
 
-	@JsonProperty("nsId")
-	public void setNsId(Long nsId) {
-		this.nsId = nsId;
-	}
+  @JsonProperty("nsId")
+  public void setNsId(Long nsId) {
+    this.nsId = nsId;
+  }
 
-	@JsonProperty("ciAttributes")
-	public CiAttributes getCiAttributes() {
-		return ciAttributes;
-	}
+  @JsonProperty("ciAttributes")
+  public CiAttributes getCiAttributes() {
+    return ciAttributes;
+  }
 
-	@JsonProperty("ciAttributes")
-	public void setCiAttributes(CiAttributes ciAttributes) {
-		this.ciAttributes = ciAttributes;
-	}
+  @JsonProperty("ciAttributes")
+  public void setCiAttributes(CiAttributes ciAttributes) {
+    this.ciAttributes = ciAttributes;
+  }
 
-	@JsonProperty("attrProps")
-	public AttrProps getAttrProps() {
-		return attrProps;
-	}
+  @JsonProperty("attrProps")
+  public AttrProps getAttrProps() {
+    return attrProps;
+  }
 
-	@JsonProperty("attrProps")
-	public void setAttrProps(AttrProps attrProps) {
-		this.attrProps = attrProps;
-	}
+  @JsonProperty("attrProps")
+  public void setAttrProps(AttrProps attrProps) {
+    this.attrProps = attrProps;
+  }
 
-	@JsonAnyGetter
-	public Map<String, Object> getAdditionalProperties() {
-		return this.additionalProperties;
-	}
+  @JsonAnyGetter
+  public Map<String, Object> getAdditionalProperties() {
+    return this.additionalProperties;
+  }
 
-	@JsonAnySetter
-	public void setAdditionalProperty(String name, Object value) {
-		this.additionalProperties.put(name, value);
-	}
+  @JsonAnySetter
+  public void setAdditionalProperty(String name, Object value) {
+    this.additionalProperties.put(name, value);
+  }
 
 }

--- a/src/main/java/com/oneops/api/resource/model/Deployment.java
+++ b/src/main/java/com/oneops/api/resource/model/Deployment.java
@@ -2,6 +2,7 @@ package com.oneops.api.resource.model;
 
 import java.util.HashMap;
 import java.util.Map;
+
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
 import com.fasterxml.jackson.annotation.JsonIgnore;
@@ -10,214 +11,214 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
-@JsonPropertyOrder({ "deploymentId", "releaseId", "maxExecOrder", "nsPath", "deploymentState", "processId", "createdBy",
-		"updatedBy", "description", "comments", "ops", "autoPauseExecOrders", "created", "updated", "flags",
-		"continueOnFailure" })
+@JsonPropertyOrder({"deploymentId", "releaseId", "maxExecOrder", "nsPath", "deploymentState", "processId", "createdBy",
+    "updatedBy", "description", "comments", "ops", "autoPauseExecOrders", "created", "updated", "flags",
+    "continueOnFailure"})
 public class Deployment {
 
-	@JsonProperty("deploymentId")
-	private Long deploymentId;
-	@JsonProperty("releaseId")
-	private Long releaseId;
-	@JsonProperty("maxExecOrder")
-	private Integer maxExecOrder;
-	@JsonProperty("nsPath")
-	private String nsPath;
-	@JsonProperty("deploymentState")
-	private String deploymentState;
-	@JsonProperty("processId")
-	private String processId;
-	@JsonProperty("createdBy")
-	private String createdBy;
-	@JsonProperty("updatedBy")
-	private String updatedBy;
-	@JsonProperty("description")
-	private Object description;
-	@JsonProperty("comments")
-	private String comments;
-	@JsonProperty("ops")
-	private Object ops;
-	@JsonProperty("autoPauseExecOrders")
-	private Object autoPauseExecOrders;
-	@JsonProperty("created")
-	private Long created;
-	@JsonProperty("updated")
-	private Long updated;
-	@JsonProperty("flags")
-	private Integer flags;
-	@JsonProperty("continueOnFailure")
-	private Boolean continueOnFailure;
-	@JsonIgnore
-	private Map<String, Object> additionalProperties = new HashMap<String, Object>();
+  @JsonProperty("deploymentId")
+  private Long deploymentId;
+  @JsonProperty("releaseId")
+  private Long releaseId;
+  @JsonProperty("maxExecOrder")
+  private Integer maxExecOrder;
+  @JsonProperty("nsPath")
+  private String nsPath;
+  @JsonProperty("deploymentState")
+  private String deploymentState;
+  @JsonProperty("processId")
+  private String processId;
+  @JsonProperty("createdBy")
+  private String createdBy;
+  @JsonProperty("updatedBy")
+  private String updatedBy;
+  @JsonProperty("description")
+  private Object description;
+  @JsonProperty("comments")
+  private String comments;
+  @JsonProperty("ops")
+  private Object ops;
+  @JsonProperty("autoPauseExecOrders")
+  private Object autoPauseExecOrders;
+  @JsonProperty("created")
+  private Long created;
+  @JsonProperty("updated")
+  private Long updated;
+  @JsonProperty("flags")
+  private Integer flags;
+  @JsonProperty("continueOnFailure")
+  private Boolean continueOnFailure;
+  @JsonIgnore
+  private Map<String, Object> additionalProperties = new HashMap<String, Object>();
 
-	@JsonProperty("deploymentId")
-	public Long getDeploymentId() {
-		return deploymentId;
-	}
+  @JsonProperty("deploymentId")
+  public Long getDeploymentId() {
+    return deploymentId;
+  }
 
-	@JsonProperty("deploymentId")
-	public void setDeploymentId(Long deploymentId) {
-		this.deploymentId = deploymentId;
-	}
+  @JsonProperty("deploymentId")
+  public void setDeploymentId(Long deploymentId) {
+    this.deploymentId = deploymentId;
+  }
 
-	@JsonProperty("releaseId")
-	public Long getReleaseId() {
-		return releaseId;
-	}
+  @JsonProperty("releaseId")
+  public Long getReleaseId() {
+    return releaseId;
+  }
 
-	@JsonProperty("releaseId")
-	public void setReleaseId(Long releaseId) {
-		this.releaseId = releaseId;
-	}
+  @JsonProperty("releaseId")
+  public void setReleaseId(Long releaseId) {
+    this.releaseId = releaseId;
+  }
 
-	@JsonProperty("maxExecOrder")
-	public Integer getMaxExecOrder() {
-		return maxExecOrder;
-	}
+  @JsonProperty("maxExecOrder")
+  public Integer getMaxExecOrder() {
+    return maxExecOrder;
+  }
 
-	@JsonProperty("maxExecOrder")
-	public void setMaxExecOrder(Integer maxExecOrder) {
-		this.maxExecOrder = maxExecOrder;
-	}
+  @JsonProperty("maxExecOrder")
+  public void setMaxExecOrder(Integer maxExecOrder) {
+    this.maxExecOrder = maxExecOrder;
+  }
 
-	@JsonProperty("nsPath")
-	public String getNsPath() {
-		return nsPath;
-	}
+  @JsonProperty("nsPath")
+  public String getNsPath() {
+    return nsPath;
+  }
 
-	@JsonProperty("nsPath")
-	public void setNsPath(String nsPath) {
-		this.nsPath = nsPath;
-	}
+  @JsonProperty("nsPath")
+  public void setNsPath(String nsPath) {
+    this.nsPath = nsPath;
+  }
 
-	@JsonProperty("deploymentState")
-	public String getDeploymentState() {
-		return deploymentState;
-	}
+  @JsonProperty("deploymentState")
+  public String getDeploymentState() {
+    return deploymentState;
+  }
 
-	@JsonProperty("deploymentState")
-	public void setDeploymentState(String deploymentState) {
-		this.deploymentState = deploymentState;
-	}
+  @JsonProperty("deploymentState")
+  public void setDeploymentState(String deploymentState) {
+    this.deploymentState = deploymentState;
+  }
 
-	@JsonProperty("processId")
-	public String getProcessId() {
-		return processId;
-	}
+  @JsonProperty("processId")
+  public String getProcessId() {
+    return processId;
+  }
 
-	@JsonProperty("processId")
-	public void setProcessId(String processId) {
-		this.processId = processId;
-	}
+  @JsonProperty("processId")
+  public void setProcessId(String processId) {
+    this.processId = processId;
+  }
 
-	@JsonProperty("createdBy")
-	public String getCreatedBy() {
-		return createdBy;
-	}
+  @JsonProperty("createdBy")
+  public String getCreatedBy() {
+    return createdBy;
+  }
 
-	@JsonProperty("createdBy")
-	public void setCreatedBy(String createdBy) {
-		this.createdBy = createdBy;
-	}
+  @JsonProperty("createdBy")
+  public void setCreatedBy(String createdBy) {
+    this.createdBy = createdBy;
+  }
 
-	@JsonProperty("updatedBy")
-	public String getUpdatedBy() {
-		return updatedBy;
-	}
+  @JsonProperty("updatedBy")
+  public String getUpdatedBy() {
+    return updatedBy;
+  }
 
-	@JsonProperty("updatedBy")
-	public void setUpdatedBy(String updatedBy) {
-		this.updatedBy = updatedBy;
-	}
+  @JsonProperty("updatedBy")
+  public void setUpdatedBy(String updatedBy) {
+    this.updatedBy = updatedBy;
+  }
 
-	@JsonProperty("description")
-	public Object getDescription() {
-		return description;
-	}
+  @JsonProperty("description")
+  public Object getDescription() {
+    return description;
+  }
 
-	@JsonProperty("description")
-	public void setDescription(Object description) {
-		this.description = description;
-	}
+  @JsonProperty("description")
+  public void setDescription(Object description) {
+    this.description = description;
+  }
 
-	@JsonProperty("comments")
-	public String getComments() {
-		return comments;
-	}
+  @JsonProperty("comments")
+  public String getComments() {
+    return comments;
+  }
 
-	@JsonProperty("comments")
-	public void setComments(String comments) {
-		this.comments = comments;
-	}
+  @JsonProperty("comments")
+  public void setComments(String comments) {
+    this.comments = comments;
+  }
 
-	@JsonProperty("ops")
-	public Object getOps() {
-		return ops;
-	}
+  @JsonProperty("ops")
+  public Object getOps() {
+    return ops;
+  }
 
-	@JsonProperty("ops")
-	public void setOps(Object ops) {
-		this.ops = ops;
-	}
+  @JsonProperty("ops")
+  public void setOps(Object ops) {
+    this.ops = ops;
+  }
 
-	@JsonProperty("autoPauseExecOrders")
-	public Object getAutoPauseExecOrders() {
-		return autoPauseExecOrders;
-	}
+  @JsonProperty("autoPauseExecOrders")
+  public Object getAutoPauseExecOrders() {
+    return autoPauseExecOrders;
+  }
 
-	@JsonProperty("autoPauseExecOrders")
-	public void setAutoPauseExecOrders(Object autoPauseExecOrders) {
-		this.autoPauseExecOrders = autoPauseExecOrders;
-	}
+  @JsonProperty("autoPauseExecOrders")
+  public void setAutoPauseExecOrders(Object autoPauseExecOrders) {
+    this.autoPauseExecOrders = autoPauseExecOrders;
+  }
 
-	@JsonProperty("created")
-	public Long getCreated() {
-		return created;
-	}
+  @JsonProperty("created")
+  public Long getCreated() {
+    return created;
+  }
 
-	@JsonProperty("created")
-	public void setCreated(Long created) {
-		this.created = created;
-	}
+  @JsonProperty("created")
+  public void setCreated(Long created) {
+    this.created = created;
+  }
 
-	@JsonProperty("updated")
-	public Long getUpdated() {
-		return updated;
-	}
+  @JsonProperty("updated")
+  public Long getUpdated() {
+    return updated;
+  }
 
-	@JsonProperty("updated")
-	public void setUpdated(Long updated) {
-		this.updated = updated;
-	}
+  @JsonProperty("updated")
+  public void setUpdated(Long updated) {
+    this.updated = updated;
+  }
 
-	@JsonProperty("flags")
-	public Integer getFlags() {
-		return flags;
-	}
+  @JsonProperty("flags")
+  public Integer getFlags() {
+    return flags;
+  }
 
-	@JsonProperty("flags")
-	public void setFlags(Integer flags) {
-		this.flags = flags;
-	}
+  @JsonProperty("flags")
+  public void setFlags(Integer flags) {
+    this.flags = flags;
+  }
 
-	@JsonProperty("continueOnFailure")
-	public Boolean getContinueOnFailure() {
-		return continueOnFailure;
-	}
+  @JsonProperty("continueOnFailure")
+  public Boolean getContinueOnFailure() {
+    return continueOnFailure;
+  }
 
-	@JsonProperty("continueOnFailure")
-	public void setContinueOnFailure(Boolean continueOnFailure) {
-		this.continueOnFailure = continueOnFailure;
-	}
+  @JsonProperty("continueOnFailure")
+  public void setContinueOnFailure(Boolean continueOnFailure) {
+    this.continueOnFailure = continueOnFailure;
+  }
 
-	@JsonAnyGetter
-	public Map<String, Object> getAdditionalProperties() {
-		return this.additionalProperties;
-	}
+  @JsonAnyGetter
+  public Map<String, Object> getAdditionalProperties() {
+    return this.additionalProperties;
+  }
 
-	@JsonAnySetter
-	public void setAdditionalProperty(String name, Object value) {
-		this.additionalProperties.put(name, value);
-	}
+  @JsonAnySetter
+  public void setAdditionalProperty(String name, Object value) {
+    this.additionalProperties.put(name, value);
+  }
 
 }

--- a/src/main/java/com/oneops/api/resource/model/DeploymentRFC.java
+++ b/src/main/java/com/oneops/api/resource/model/DeploymentRFC.java
@@ -3,6 +3,7 @@ package com.oneops.api.resource.model;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
 import com.fasterxml.jackson.annotation.JsonIgnore;
@@ -11,32 +12,32 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
-@JsonPropertyOrder({ "rfc_cis" })
+@JsonPropertyOrder({"rfc_cis"})
 public class DeploymentRFC {
 
-	@JsonProperty("rfc_cis")
-	private List<RfcCi> rfcCis = null;
-	@JsonIgnore
-	private Map<String, Object> additionalProperties = new HashMap<String, Object>();
+  @JsonProperty("rfc_cis")
+  private List<RfcCi> rfcCis = null;
+  @JsonIgnore
+  private Map<String, Object> additionalProperties = new HashMap<String, Object>();
 
-	@JsonProperty("rfc_cis")
-	public List<RfcCi> getRfcCis() {
-		return rfcCis;
-	}
+  @JsonProperty("rfc_cis")
+  public List<RfcCi> getRfcCis() {
+    return rfcCis;
+  }
 
-	@JsonProperty("rfc_cis")
-	public void setRfcCis(List<RfcCi> rfcCis) {
-		this.rfcCis = rfcCis;
-	}
+  @JsonProperty("rfc_cis")
+  public void setRfcCis(List<RfcCi> rfcCis) {
+    this.rfcCis = rfcCis;
+  }
 
-	@JsonAnyGetter
-	public Map<String, Object> getAdditionalProperties() {
-		return this.additionalProperties;
-	}
+  @JsonAnyGetter
+  public Map<String, Object> getAdditionalProperties() {
+    return this.additionalProperties;
+  }
 
-	@JsonAnySetter
-	public void setAdditionalProperty(String name, Object value) {
-		this.additionalProperties.put(name, value);
-	}
+  @JsonAnySetter
+  public void setAdditionalProperty(String name, Object value) {
+    this.additionalProperties.put(name, value);
+  }
 
 }

--- a/src/main/java/com/oneops/api/resource/model/Log.java
+++ b/src/main/java/com/oneops/api/resource/model/Log.java
@@ -12,44 +12,44 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
-@JsonPropertyOrder({ "id", "logData" })
+@JsonPropertyOrder({"id", "logData"})
 public class Log {
 
-	@JsonProperty("id")
-	private String id;
-	@JsonProperty("logData")
-	private List<LogDatum> logData = null;
-	@JsonIgnore
-	private Map<String, Object> additionalProperties = new HashMap<String, Object>();
+  @JsonProperty("id")
+  private String id;
+  @JsonProperty("logData")
+  private List<LogDatum> logData = null;
+  @JsonIgnore
+  private Map<String, Object> additionalProperties = new HashMap<String, Object>();
 
-	@JsonProperty("id")
-	public String getId() {
-		return id;
-	}
+  @JsonProperty("id")
+  public String getId() {
+    return id;
+  }
 
-	@JsonProperty("id")
-	public void setId(String id) {
-		this.id = id;
-	}
+  @JsonProperty("id")
+  public void setId(String id) {
+    this.id = id;
+  }
 
-	@JsonProperty("logData")
-	public List<LogDatum> getLogData() {
-		return logData;
-	}
+  @JsonProperty("logData")
+  public List<LogDatum> getLogData() {
+    return logData;
+  }
 
-	@JsonProperty("logData")
-	public void setLogData(List<LogDatum> logData) {
-		this.logData = logData;
-	}
+  @JsonProperty("logData")
+  public void setLogData(List<LogDatum> logData) {
+    this.logData = logData;
+  }
 
-	@JsonAnyGetter
-	public Map<String, Object> getAdditionalProperties() {
-		return this.additionalProperties;
-	}
+  @JsonAnyGetter
+  public Map<String, Object> getAdditionalProperties() {
+    return this.additionalProperties;
+  }
 
-	@JsonAnySetter
-	public void setAdditionalProperty(String name, Object value) {
-		this.additionalProperties.put(name, value);
-	}
+  @JsonAnySetter
+  public void setAdditionalProperty(String name, Object value) {
+    this.additionalProperties.put(name, value);
+  }
 
 }

--- a/src/main/java/com/oneops/api/resource/model/LogDatum.java
+++ b/src/main/java/com/oneops/api/resource/model/LogDatum.java
@@ -11,56 +11,56 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
-@JsonPropertyOrder({ "level", "requestId", "message" })
+@JsonPropertyOrder({"level", "requestId", "message"})
 public class LogDatum {
 
-	@JsonProperty("level")
-	private String level;
-	@JsonProperty("requestId")
-	private String requestId;
-	@JsonProperty("message")
-	private String message;
-	@JsonIgnore
-	private Map<String, Object> additionalProperties = new HashMap<String, Object>();
+  @JsonProperty("level")
+  private String level;
+  @JsonProperty("requestId")
+  private String requestId;
+  @JsonProperty("message")
+  private String message;
+  @JsonIgnore
+  private Map<String, Object> additionalProperties = new HashMap<String, Object>();
 
-	@JsonProperty("level")
-	public String getLevel() {
-		return level;
-	}
+  @JsonProperty("level")
+  public String getLevel() {
+    return level;
+  }
 
-	@JsonProperty("level")
-	public void setLevel(String level) {
-		this.level = level;
-	}
+  @JsonProperty("level")
+  public void setLevel(String level) {
+    this.level = level;
+  }
 
-	@JsonProperty("requestId")
-	public String getRequestId() {
-		return requestId;
-	}
+  @JsonProperty("requestId")
+  public String getRequestId() {
+    return requestId;
+  }
 
-	@JsonProperty("requestId")
-	public void setRequestId(String requestId) {
-		this.requestId = requestId;
-	}
+  @JsonProperty("requestId")
+  public void setRequestId(String requestId) {
+    this.requestId = requestId;
+  }
 
-	@JsonProperty("message")
-	public String getMessage() {
-		return message;
-	}
+  @JsonProperty("message")
+  public String getMessage() {
+    return message;
+  }
 
-	@JsonProperty("message")
-	public void setMessage(String message) {
-		this.message = message;
-	}
+  @JsonProperty("message")
+  public void setMessage(String message) {
+    this.message = message;
+  }
 
-	@JsonAnyGetter
-	public Map<String, Object> getAdditionalProperties() {
-		return this.additionalProperties;
-	}
+  @JsonAnyGetter
+  public Map<String, Object> getAdditionalProperties() {
+    return this.additionalProperties;
+  }
 
-	@JsonAnySetter
-	public void setAdditionalProperty(String name, Object value) {
-		this.additionalProperties.put(name, value);
-	}
+  @JsonAnySetter
+  public void setAdditionalProperty(String name, Object value) {
+    this.additionalProperties.put(name, value);
+  }
 
 }

--- a/src/main/java/com/oneops/api/resource/model/Organization.java
+++ b/src/main/java/com/oneops/api/resource/model/Organization.java
@@ -3,8 +3,6 @@ package com.oneops.api.resource.model;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.apache.commons.lang3.builder.ToStringBuilder;
-
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
 import com.fasterxml.jackson.annotation.JsonIgnore;
@@ -13,146 +11,141 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
-@JsonPropertyOrder({ "id", "name", "created_at", "updated_at", "cms_id", "assemblies", "catalogs", "services",
-		"announcement", "full_name" })
+@JsonPropertyOrder({"id", "name", "created_at", "updated_at", "cms_id", "assemblies", "catalogs", "services",
+    "announcement", "full_name"})
 public class Organization {
 
-	@JsonProperty("id")
-	private Long id;
-	@JsonProperty("name")
-	private String name;
-	@JsonProperty("created_at")
-	private String createdAt;
-	@JsonProperty("updated_at")
-	private String updatedAt;
-	@JsonProperty("cms_id")
-	private Long cmsId;
-	@JsonProperty("assemblies")
-	private Boolean assemblies;
-	@JsonProperty("catalogs")
-	private Boolean catalogs;
-	@JsonProperty("services")
-	private Boolean services;
-	@JsonProperty("announcement")
-	private Object announcement;
-	@JsonProperty("full_name")
-	private Object fullName;
-	@JsonIgnore
-	private Map<String, Object> additionalProperties = new HashMap<String, Object>();
+  @JsonProperty("id")
+  private Long id;
+  @JsonProperty("name")
+  private String name;
+  @JsonProperty("created_at")
+  private String createdAt;
+  @JsonProperty("updated_at")
+  private String updatedAt;
+  @JsonProperty("cms_id")
+  private Long cmsId;
+  @JsonProperty("assemblies")
+  private Boolean assemblies;
+  @JsonProperty("catalogs")
+  private Boolean catalogs;
+  @JsonProperty("services")
+  private Boolean services;
+  @JsonProperty("announcement")
+  private Object announcement;
+  @JsonProperty("full_name")
+  private Object fullName;
+  @JsonIgnore
+  private Map<String, Object> additionalProperties = new HashMap<String, Object>();
 
-	@JsonProperty("id")
-	public Long getId() {
-		return id;
-	}
+  @JsonProperty("id")
+  public Long getId() {
+    return id;
+  }
 
-	@JsonProperty("id")
-	public void setId(Long id) {
-		this.id = id;
-	}
+  @JsonProperty("id")
+  public void setId(Long id) {
+    this.id = id;
+  }
 
-	@JsonProperty("name")
-	public String getName() {
-		return name;
-	}
+  @JsonProperty("name")
+  public String getName() {
+    return name;
+  }
 
-	@JsonProperty("name")
-	public void setName(String name) {
-		this.name = name;
-	}
+  @JsonProperty("name")
+  public void setName(String name) {
+    this.name = name;
+  }
 
-	@JsonProperty("created_at")
-	public String getCreatedAt() {
-		return createdAt;
-	}
+  @JsonProperty("created_at")
+  public String getCreatedAt() {
+    return createdAt;
+  }
 
-	@JsonProperty("created_at")
-	public void setCreatedAt(String createdAt) {
-		this.createdAt = createdAt;
-	}
+  @JsonProperty("created_at")
+  public void setCreatedAt(String createdAt) {
+    this.createdAt = createdAt;
+  }
 
-	@JsonProperty("updated_at")
-	public String getUpdatedAt() {
-		return updatedAt;
-	}
+  @JsonProperty("updated_at")
+  public String getUpdatedAt() {
+    return updatedAt;
+  }
 
-	@JsonProperty("updated_at")
-	public void setUpdatedAt(String updatedAt) {
-		this.updatedAt = updatedAt;
-	}
+  @JsonProperty("updated_at")
+  public void setUpdatedAt(String updatedAt) {
+    this.updatedAt = updatedAt;
+  }
 
-	@JsonProperty("cms_id")
-	public Long getCmsId() {
-		return cmsId;
-	}
+  @JsonProperty("cms_id")
+  public Long getCmsId() {
+    return cmsId;
+  }
 
-	@JsonProperty("cms_id")
-	public void setCmsId(Long cmsId) {
-		this.cmsId = cmsId;
-	}
+  @JsonProperty("cms_id")
+  public void setCmsId(Long cmsId) {
+    this.cmsId = cmsId;
+  }
 
-	@JsonProperty("assemblies")
-	public Boolean getAssemblies() {
-		return assemblies;
-	}
+  @JsonProperty("assemblies")
+  public Boolean getAssemblies() {
+    return assemblies;
+  }
 
-	@JsonProperty("assemblies")
-	public void setAssemblies(Boolean assemblies) {
-		this.assemblies = assemblies;
-	}
+  @JsonProperty("assemblies")
+  public void setAssemblies(Boolean assemblies) {
+    this.assemblies = assemblies;
+  }
 
-	@JsonProperty("catalogs")
-	public Boolean getCatalogs() {
-		return catalogs;
-	}
+  @JsonProperty("catalogs")
+  public Boolean getCatalogs() {
+    return catalogs;
+  }
 
-	@JsonProperty("catalogs")
-	public void setCatalogs(Boolean catalogs) {
-		this.catalogs = catalogs;
-	}
+  @JsonProperty("catalogs")
+  public void setCatalogs(Boolean catalogs) {
+    this.catalogs = catalogs;
+  }
 
-	@JsonProperty("services")
-	public Boolean getServices() {
-		return services;
-	}
+  @JsonProperty("services")
+  public Boolean getServices() {
+    return services;
+  }
 
-	@JsonProperty("services")
-	public void setServices(Boolean services) {
-		this.services = services;
-	}
+  @JsonProperty("services")
+  public void setServices(Boolean services) {
+    this.services = services;
+  }
 
-	@JsonProperty("announcement")
-	public Object getAnnouncement() {
-		return announcement;
-	}
+  @JsonProperty("announcement")
+  public Object getAnnouncement() {
+    return announcement;
+  }
 
-	@JsonProperty("announcement")
-	public void setAnnouncement(Object announcement) {
-		this.announcement = announcement;
-	}
+  @JsonProperty("announcement")
+  public void setAnnouncement(Object announcement) {
+    this.announcement = announcement;
+  }
 
-	@JsonProperty("full_name")
-	public Object getFullName() {
-		return fullName;
-	}
+  @JsonProperty("full_name")
+  public Object getFullName() {
+    return fullName;
+  }
 
-	@JsonProperty("full_name")
-	public void setFullName(Object fullName) {
-		this.fullName = fullName;
-	}
+  @JsonProperty("full_name")
+  public void setFullName(Object fullName) {
+    this.fullName = fullName;
+  }
 
-	@Override
-	public String toString() {
-		return ToStringBuilder.reflectionToString(this);
-	}
+  @JsonAnyGetter
+  public Map<String, Object> getAdditionalProperties() {
+    return this.additionalProperties;
+  }
 
-	@JsonAnyGetter
-	public Map<String, Object> getAdditionalProperties() {
-		return this.additionalProperties;
-	}
-
-	@JsonAnySetter
-	public void setAdditionalProperty(String name, Object value) {
-		this.additionalProperties.put(name, value);
-	}
+  @JsonAnySetter
+  public void setAdditionalProperty(String name, Object value) {
+    this.additionalProperties.put(name, value);
+  }
 
 }

--- a/src/main/java/com/oneops/api/resource/model/Procedure.java
+++ b/src/main/java/com/oneops/api/resource/model/Procedure.java
@@ -3,6 +3,7 @@ package com.oneops.api.resource.model;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
 import com.fasterxml.jackson.annotation.JsonIgnore;
@@ -11,201 +12,201 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
-@JsonPropertyOrder({ "ciId", "procedureCiId", "procedureState", "arglist", "definition", "force", "procedureId",
-		"procedureName", "maxExecOrder", "createdBy", "created", "updated", "nsPath", "forceExecution", "actions" })
+@JsonPropertyOrder({"ciId", "procedureCiId", "procedureState", "arglist", "definition", "force", "procedureId",
+    "procedureName", "maxExecOrder", "createdBy", "created", "updated", "nsPath", "forceExecution", "actions"})
 public class Procedure {
 
-	@JsonProperty("ciId")
-	private Long ciId;
-	@JsonProperty("procedureCiId")
-	private Long procedureCiId;
-	@JsonProperty("procedureState")
-	private String procedureState;
-	@JsonProperty("arglist")
-	private String arglist;
-	@JsonProperty("definition")
-	private Object definition;
-	@JsonProperty("force")
-	private String force;
-	@JsonProperty("procedureId")
-	private Long procedureId;
-	@JsonProperty("procedureName")
-	private String procedureName;
-	@JsonProperty("maxExecOrder")
-	private Long maxExecOrder;
-	@JsonProperty("createdBy")
-	private String createdBy;
-	@JsonProperty("created")
-	private Long created;
-	@JsonProperty("updated")
-	private Long updated;
-	@JsonProperty("nsPath")
-	private Object nsPath;
-	@JsonProperty("forceExecution")
-	private Boolean forceExecution;
-	@JsonProperty("actions")
-	private List<Action> actions = null;
-	@JsonIgnore
-	private Map<String, Object> additionalProperties = new HashMap<String, Object>();
+  @JsonProperty("ciId")
+  private Long ciId;
+  @JsonProperty("procedureCiId")
+  private Long procedureCiId;
+  @JsonProperty("procedureState")
+  private String procedureState;
+  @JsonProperty("arglist")
+  private String arglist;
+  @JsonProperty("definition")
+  private Object definition;
+  @JsonProperty("force")
+  private String force;
+  @JsonProperty("procedureId")
+  private Long procedureId;
+  @JsonProperty("procedureName")
+  private String procedureName;
+  @JsonProperty("maxExecOrder")
+  private Long maxExecOrder;
+  @JsonProperty("createdBy")
+  private String createdBy;
+  @JsonProperty("created")
+  private Long created;
+  @JsonProperty("updated")
+  private Long updated;
+  @JsonProperty("nsPath")
+  private Object nsPath;
+  @JsonProperty("forceExecution")
+  private Boolean forceExecution;
+  @JsonProperty("actions")
+  private List<Action> actions = null;
+  @JsonIgnore
+  private Map<String, Object> additionalProperties = new HashMap<String, Object>();
 
-	@JsonProperty("ciId")
-	public Long getCiId() {
-		return ciId;
-	}
+  @JsonProperty("ciId")
+  public Long getCiId() {
+    return ciId;
+  }
 
-	@JsonProperty("ciId")
-	public void setCiId(Long ciId) {
-		this.ciId = ciId;
-	}
+  @JsonProperty("ciId")
+  public void setCiId(Long ciId) {
+    this.ciId = ciId;
+  }
 
-	@JsonProperty("procedureCiId")
-	public Long getProcedureCiId() {
-		return procedureCiId;
-	}
+  @JsonProperty("procedureCiId")
+  public Long getProcedureCiId() {
+    return procedureCiId;
+  }
 
-	@JsonProperty("procedureCiId")
-	public void setProcedureCiId(Long procedureCiId) {
-		this.procedureCiId = procedureCiId;
-	}
+  @JsonProperty("procedureCiId")
+  public void setProcedureCiId(Long procedureCiId) {
+    this.procedureCiId = procedureCiId;
+  }
 
-	@JsonProperty("procedureState")
-	public String getProcedureState() {
-		return procedureState;
-	}
+  @JsonProperty("procedureState")
+  public String getProcedureState() {
+    return procedureState;
+  }
 
-	@JsonProperty("procedureState")
-	public void setProcedureState(String procedureState) {
-		this.procedureState = procedureState;
-	}
+  @JsonProperty("procedureState")
+  public void setProcedureState(String procedureState) {
+    this.procedureState = procedureState;
+  }
 
-	@JsonProperty("arglist")
-	public String getArglist() {
-		return arglist;
-	}
+  @JsonProperty("arglist")
+  public String getArglist() {
+    return arglist;
+  }
 
-	@JsonProperty("arglist")
-	public void setArglist(String arglist) {
-		this.arglist = arglist;
-	}
+  @JsonProperty("arglist")
+  public void setArglist(String arglist) {
+    this.arglist = arglist;
+  }
 
-	@JsonProperty("definition")
-	public Object getDefinition() {
-		return definition;
-	}
+  @JsonProperty("definition")
+  public Object getDefinition() {
+    return definition;
+  }
 
-	@JsonProperty("definition")
-	public void setDefinition(Object definition) {
-		this.definition = definition;
-	}
+  @JsonProperty("definition")
+  public void setDefinition(Object definition) {
+    this.definition = definition;
+  }
 
-	@JsonProperty("force")
-	public String getForce() {
-		return force;
-	}
+  @JsonProperty("force")
+  public String getForce() {
+    return force;
+  }
 
-	@JsonProperty("force")
-	public void setForce(String force) {
-		this.force = force;
-	}
+  @JsonProperty("force")
+  public void setForce(String force) {
+    this.force = force;
+  }
 
-	@JsonProperty("procedureId")
-	public Long getProcedureId() {
-		return procedureId;
-	}
+  @JsonProperty("procedureId")
+  public Long getProcedureId() {
+    return procedureId;
+  }
 
-	@JsonProperty("procedureId")
-	public void setProcedureId(Long procedureId) {
-		this.procedureId = procedureId;
-	}
+  @JsonProperty("procedureId")
+  public void setProcedureId(Long procedureId) {
+    this.procedureId = procedureId;
+  }
 
-	@JsonProperty("procedureName")
-	public String getProcedureName() {
-		return procedureName;
-	}
+  @JsonProperty("procedureName")
+  public String getProcedureName() {
+    return procedureName;
+  }
 
-	@JsonProperty("procedureName")
-	public void setProcedureName(String procedureName) {
-		this.procedureName = procedureName;
-	}
+  @JsonProperty("procedureName")
+  public void setProcedureName(String procedureName) {
+    this.procedureName = procedureName;
+  }
 
-	@JsonProperty("maxExecOrder")
-	public Long getMaxExecOrder() {
-		return maxExecOrder;
-	}
+  @JsonProperty("maxExecOrder")
+  public Long getMaxExecOrder() {
+    return maxExecOrder;
+  }
 
-	@JsonProperty("maxExecOrder")
-	public void setMaxExecOrder(Long maxExecOrder) {
-		this.maxExecOrder = maxExecOrder;
-	}
+  @JsonProperty("maxExecOrder")
+  public void setMaxExecOrder(Long maxExecOrder) {
+    this.maxExecOrder = maxExecOrder;
+  }
 
-	@JsonProperty("createdBy")
-	public String getCreatedBy() {
-		return createdBy;
-	}
+  @JsonProperty("createdBy")
+  public String getCreatedBy() {
+    return createdBy;
+  }
 
-	@JsonProperty("createdBy")
-	public void setCreatedBy(String createdBy) {
-		this.createdBy = createdBy;
-	}
+  @JsonProperty("createdBy")
+  public void setCreatedBy(String createdBy) {
+    this.createdBy = createdBy;
+  }
 
-	@JsonProperty("created")
-	public Long getCreated() {
-		return created;
-	}
+  @JsonProperty("created")
+  public Long getCreated() {
+    return created;
+  }
 
-	@JsonProperty("created")
-	public void setCreated(Long created) {
-		this.created = created;
-	}
+  @JsonProperty("created")
+  public void setCreated(Long created) {
+    this.created = created;
+  }
 
-	@JsonProperty("updated")
-	public Long getUpdated() {
-		return updated;
-	}
+  @JsonProperty("updated")
+  public Long getUpdated() {
+    return updated;
+  }
 
-	@JsonProperty("updated")
-	public void setUpdated(Long updated) {
-		this.updated = updated;
-	}
+  @JsonProperty("updated")
+  public void setUpdated(Long updated) {
+    this.updated = updated;
+  }
 
-	@JsonProperty("nsPath")
-	public Object getNsPath() {
-		return nsPath;
-	}
+  @JsonProperty("nsPath")
+  public Object getNsPath() {
+    return nsPath;
+  }
 
-	@JsonProperty("nsPath")
-	public void setNsPath(Object nsPath) {
-		this.nsPath = nsPath;
-	}
+  @JsonProperty("nsPath")
+  public void setNsPath(Object nsPath) {
+    this.nsPath = nsPath;
+  }
 
-	@JsonProperty("forceExecution")
-	public Boolean getForceExecution() {
-		return forceExecution;
-	}
+  @JsonProperty("forceExecution")
+  public Boolean getForceExecution() {
+    return forceExecution;
+  }
 
-	@JsonProperty("forceExecution")
-	public void setForceExecution(Boolean forceExecution) {
-		this.forceExecution = forceExecution;
-	}
+  @JsonProperty("forceExecution")
+  public void setForceExecution(Boolean forceExecution) {
+    this.forceExecution = forceExecution;
+  }
 
-	@JsonProperty("actions")
-	public List<Action> getActions() {
-		return actions;
-	}
+  @JsonProperty("actions")
+  public List<Action> getActions() {
+    return actions;
+  }
 
-	@JsonProperty("actions")
-	public void setActions(List<Action> actions) {
-		this.actions = actions;
-	}
+  @JsonProperty("actions")
+  public void setActions(List<Action> actions) {
+    this.actions = actions;
+  }
 
-	@JsonAnyGetter
-	public Map<String, Object> getAdditionalProperties() {
-		return this.additionalProperties;
-	}
+  @JsonAnyGetter
+  public Map<String, Object> getAdditionalProperties() {
+    return this.additionalProperties;
+  }
 
-	@JsonAnySetter
-	public void setAdditionalProperty(String name, Object value) {
-		this.additionalProperties.put(name, value);
-	}
+  @JsonAnySetter
+  public void setAdditionalProperty(String name, Object value) {
+    this.additionalProperties.put(name, value);
+  }
 
 }

--- a/src/main/java/com/oneops/api/resource/model/RedundancyConfig.java
+++ b/src/main/java/com/oneops/api/resource/model/RedundancyConfig.java
@@ -2,47 +2,58 @@ package com.oneops.api.resource.model;
 
 public class RedundancyConfig {
 
-	private int max = 10;
-	private int current = 2;
-	private int min = 2;
-	private int stepUp = 1;
-	private int stepDown = 1;
-	private int percentDeploy = 100;
-	
-	public int getMax() {
-		return max;
-	}
-	public void setMax(int max) {
-		this.max = max;
-	}
-	public int getCurrent() {
-		return current;
-	}
-	public void setCurrent(int current) {
-		this.current = current;
-	}
-	public int getMin() {
-		return min;
-	}
-	public void setMin(int min) {
-		this.min = min;
-	}
-	public int getStepUp() {
-		return stepUp;
-	}
-	public void setStepUp(int stepUp) {
-		this.stepUp = stepUp;
-	}
-	public int getStepDown() {
-		return stepDown;
-	}
-	public void setStepDown(int stepDown) {
-		this.stepDown = stepDown;
-	}
-	public int getPercentDeploy() {
-		return percentDeploy;
-	}
-	public void setPercentDeploy(int percentDeploy) {
-		this.percentDeploy = percentDeploy;
-	}
+  private int max = 10;
+  private int current = 2;
+  private int min = 2;
+  private int stepUp = 1;
+  private int stepDown = 1;
+  private int percentDeploy = 100;
+
+  public int getMax() {
+    return max;
+  }
+
+  public void setMax(int max) {
+    this.max = max;
+  }
+
+  public int getCurrent() {
+    return current;
+  }
+
+  public void setCurrent(int current) {
+    this.current = current;
+  }
+
+  public int getMin() {
+    return min;
+  }
+
+  public void setMin(int min) {
+    this.min = min;
+  }
+
+  public int getStepUp() {
+    return stepUp;
+  }
+
+  public void setStepUp(int stepUp) {
+    this.stepUp = stepUp;
+  }
+
+  public int getStepDown() {
+    return stepDown;
+  }
+
+  public void setStepDown(int stepDown) {
+    this.stepDown = stepDown;
+  }
+
+  public int getPercentDeploy() {
+    return percentDeploy;
+  }
+
+  public void setPercentDeploy(int percentDeploy) {
+    this.percentDeploy = percentDeploy;
+  }
 }

--- a/src/main/java/com/oneops/api/resource/model/Release.java
+++ b/src/main/java/com/oneops/api/resource/model/Release.java
@@ -2,6 +2,7 @@ package com.oneops.api.resource.model;
 
 import java.util.HashMap;
 import java.util.Map;
+
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
 import com.fasterxml.jackson.annotation.JsonIgnore;
@@ -10,214 +11,214 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
-@JsonPropertyOrder({ "releaseId", "nsPath", "releaseName", "createdBy", "commitedBy", "releaseState", "releaseType",
-		"description", "revision", "parentReleaseId", "created", "updated", "nsId", "releaseStateId", "ciRfcCount",
-		"relationRfcCount" })
+@JsonPropertyOrder({"releaseId", "nsPath", "releaseName", "createdBy", "commitedBy", "releaseState", "releaseType",
+    "description", "revision", "parentReleaseId", "created", "updated", "nsId", "releaseStateId", "ciRfcCount",
+    "relationRfcCount"})
 public class Release {
 
-	@JsonProperty("releaseId")
-	private Long releaseId;
-	@JsonProperty("nsPath")
-	private String nsPath;
-	@JsonProperty("releaseName")
-	private String releaseName;
-	@JsonProperty("createdBy")
-	private String createdBy;
-	@JsonProperty("commitedBy")
-	private String commitedBy;
-	@JsonProperty("releaseState")
-	private String releaseState;
-	@JsonProperty("releaseType")
-	private Object releaseType;
-	@JsonProperty("description")
-	private String description;
-	@JsonProperty("revision")
-	private Integer revision;
-	@JsonProperty("parentReleaseId")
-	private Object parentReleaseId;
-	@JsonProperty("created")
-	private Long created;
-	@JsonProperty("updated")
-	private Long updated;
-	@JsonProperty("nsId")
-	private Integer nsId;
-	@JsonProperty("releaseStateId")
-	private Integer releaseStateId;
-	@JsonProperty("ciRfcCount")
-	private Integer ciRfcCount;
-	@JsonProperty("relationRfcCount")
-	private Integer relationRfcCount;
-	@JsonIgnore
-	private Map<String, Object> additionalProperties = new HashMap<String, Object>();
+  @JsonProperty("releaseId")
+  private Long releaseId;
+  @JsonProperty("nsPath")
+  private String nsPath;
+  @JsonProperty("releaseName")
+  private String releaseName;
+  @JsonProperty("createdBy")
+  private String createdBy;
+  @JsonProperty("commitedBy")
+  private String commitedBy;
+  @JsonProperty("releaseState")
+  private String releaseState;
+  @JsonProperty("releaseType")
+  private Object releaseType;
+  @JsonProperty("description")
+  private String description;
+  @JsonProperty("revision")
+  private Integer revision;
+  @JsonProperty("parentReleaseId")
+  private Object parentReleaseId;
+  @JsonProperty("created")
+  private Long created;
+  @JsonProperty("updated")
+  private Long updated;
+  @JsonProperty("nsId")
+  private Integer nsId;
+  @JsonProperty("releaseStateId")
+  private Integer releaseStateId;
+  @JsonProperty("ciRfcCount")
+  private Integer ciRfcCount;
+  @JsonProperty("relationRfcCount")
+  private Integer relationRfcCount;
+  @JsonIgnore
+  private Map<String, Object> additionalProperties = new HashMap<String, Object>();
 
-	@JsonProperty("releaseId")
-	public Long getReleaseId() {
-		return releaseId;
-	}
+  @JsonProperty("releaseId")
+  public Long getReleaseId() {
+    return releaseId;
+  }
 
-	@JsonProperty("releaseId")
-	public void setReleaseId(Long releaseId) {
-		this.releaseId = releaseId;
-	}
+  @JsonProperty("releaseId")
+  public void setReleaseId(Long releaseId) {
+    this.releaseId = releaseId;
+  }
 
-	@JsonProperty("nsPath")
-	public String getNsPath() {
-		return nsPath;
-	}
+  @JsonProperty("nsPath")
+  public String getNsPath() {
+    return nsPath;
+  }
 
-	@JsonProperty("nsPath")
-	public void setNsPath(String nsPath) {
-		this.nsPath = nsPath;
-	}
+  @JsonProperty("nsPath")
+  public void setNsPath(String nsPath) {
+    this.nsPath = nsPath;
+  }
 
-	@JsonProperty("releaseName")
-	public String getReleaseName() {
-		return releaseName;
-	}
+  @JsonProperty("releaseName")
+  public String getReleaseName() {
+    return releaseName;
+  }
 
-	@JsonProperty("releaseName")
-	public void setReleaseName(String releaseName) {
-		this.releaseName = releaseName;
-	}
+  @JsonProperty("releaseName")
+  public void setReleaseName(String releaseName) {
+    this.releaseName = releaseName;
+  }
 
-	@JsonProperty("createdBy")
-	public String getCreatedBy() {
-		return createdBy;
-	}
+  @JsonProperty("createdBy")
+  public String getCreatedBy() {
+    return createdBy;
+  }
 
-	@JsonProperty("createdBy")
-	public void setCreatedBy(String createdBy) {
-		this.createdBy = createdBy;
-	}
+  @JsonProperty("createdBy")
+  public void setCreatedBy(String createdBy) {
+    this.createdBy = createdBy;
+  }
 
-	@JsonProperty("commitedBy")
-	public String getCommitedBy() {
-		return commitedBy;
-	}
+  @JsonProperty("commitedBy")
+  public String getCommitedBy() {
+    return commitedBy;
+  }
 
-	@JsonProperty("commitedBy")
-	public void setCommitedBy(String commitedBy) {
-		this.commitedBy = commitedBy;
-	}
+  @JsonProperty("commitedBy")
+  public void setCommitedBy(String commitedBy) {
+    this.commitedBy = commitedBy;
+  }
 
-	@JsonProperty("releaseState")
-	public String getReleaseState() {
-		return releaseState;
-	}
+  @JsonProperty("releaseState")
+  public String getReleaseState() {
+    return releaseState;
+  }
 
-	@JsonProperty("releaseState")
-	public void setReleaseState(String releaseState) {
-		this.releaseState = releaseState;
-	}
+  @JsonProperty("releaseState")
+  public void setReleaseState(String releaseState) {
+    this.releaseState = releaseState;
+  }
 
-	@JsonProperty("releaseType")
-	public Object getReleaseType() {
-		return releaseType;
-	}
+  @JsonProperty("releaseType")
+  public Object getReleaseType() {
+    return releaseType;
+  }
 
-	@JsonProperty("releaseType")
-	public void setReleaseType(Object releaseType) {
-		this.releaseType = releaseType;
-	}
+  @JsonProperty("releaseType")
+  public void setReleaseType(Object releaseType) {
+    this.releaseType = releaseType;
+  }
 
-	@JsonProperty("description")
-	public String getDescription() {
-		return description;
-	}
+  @JsonProperty("description")
+  public String getDescription() {
+    return description;
+  }
 
-	@JsonProperty("description")
-	public void setDescription(String description) {
-		this.description = description;
-	}
+  @JsonProperty("description")
+  public void setDescription(String description) {
+    this.description = description;
+  }
 
-	@JsonProperty("revision")
-	public Integer getRevision() {
-		return revision;
-	}
+  @JsonProperty("revision")
+  public Integer getRevision() {
+    return revision;
+  }
 
-	@JsonProperty("revision")
-	public void setRevision(Integer revision) {
-		this.revision = revision;
-	}
+  @JsonProperty("revision")
+  public void setRevision(Integer revision) {
+    this.revision = revision;
+  }
 
-	@JsonProperty("parentReleaseId")
-	public Object getParentReleaseId() {
-		return parentReleaseId;
-	}
+  @JsonProperty("parentReleaseId")
+  public Object getParentReleaseId() {
+    return parentReleaseId;
+  }
 
-	@JsonProperty("parentReleaseId")
-	public void setParentReleaseId(Object parentReleaseId) {
-		this.parentReleaseId = parentReleaseId;
-	}
+  @JsonProperty("parentReleaseId")
+  public void setParentReleaseId(Object parentReleaseId) {
+    this.parentReleaseId = parentReleaseId;
+  }
 
-	@JsonProperty("created")
-	public Long getCreated() {
-		return created;
-	}
+  @JsonProperty("created")
+  public Long getCreated() {
+    return created;
+  }
 
-	@JsonProperty("created")
-	public void setCreated(Long created) {
-		this.created = created;
-	}
+  @JsonProperty("created")
+  public void setCreated(Long created) {
+    this.created = created;
+  }
 
-	@JsonProperty("updated")
-	public Long getUpdated() {
-		return updated;
-	}
+  @JsonProperty("updated")
+  public Long getUpdated() {
+    return updated;
+  }
 
-	@JsonProperty("updated")
-	public void setUpdated(Long updated) {
-		this.updated = updated;
-	}
+  @JsonProperty("updated")
+  public void setUpdated(Long updated) {
+    this.updated = updated;
+  }
 
-	@JsonProperty("nsId")
-	public Integer getNsId() {
-		return nsId;
-	}
+  @JsonProperty("nsId")
+  public Integer getNsId() {
+    return nsId;
+  }
 
-	@JsonProperty("nsId")
-	public void setNsId(Integer nsId) {
-		this.nsId = nsId;
-	}
+  @JsonProperty("nsId")
+  public void setNsId(Integer nsId) {
+    this.nsId = nsId;
+  }
 
-	@JsonProperty("releaseStateId")
-	public Integer getReleaseStateId() {
-		return releaseStateId;
-	}
+  @JsonProperty("releaseStateId")
+  public Integer getReleaseStateId() {
+    return releaseStateId;
+  }
 
-	@JsonProperty("releaseStateId")
-	public void setReleaseStateId(Integer releaseStateId) {
-		this.releaseStateId = releaseStateId;
-	}
+  @JsonProperty("releaseStateId")
+  public void setReleaseStateId(Integer releaseStateId) {
+    this.releaseStateId = releaseStateId;
+  }
 
-	@JsonProperty("ciRfcCount")
-	public Integer getCiRfcCount() {
-		return ciRfcCount;
-	}
+  @JsonProperty("ciRfcCount")
+  public Integer getCiRfcCount() {
+    return ciRfcCount;
+  }
 
-	@JsonProperty("ciRfcCount")
-	public void setCiRfcCount(Integer ciRfcCount) {
-		this.ciRfcCount = ciRfcCount;
-	}
+  @JsonProperty("ciRfcCount")
+  public void setCiRfcCount(Integer ciRfcCount) {
+    this.ciRfcCount = ciRfcCount;
+  }
 
-	@JsonProperty("relationRfcCount")
-	public Integer getRelationRfcCount() {
-		return relationRfcCount;
-	}
+  @JsonProperty("relationRfcCount")
+  public Integer getRelationRfcCount() {
+    return relationRfcCount;
+  }
 
-	@JsonProperty("relationRfcCount")
-	public void setRelationRfcCount(Integer relationRfcCount) {
-		this.relationRfcCount = relationRfcCount;
-	}
+  @JsonProperty("relationRfcCount")
+  public void setRelationRfcCount(Integer relationRfcCount) {
+    this.relationRfcCount = relationRfcCount;
+  }
 
-	@JsonAnyGetter
-	public Map<String, Object> getAdditionalProperties() {
-		return this.additionalProperties;
-	}
+  @JsonAnyGetter
+  public Map<String, Object> getAdditionalProperties() {
+    return this.additionalProperties;
+  }
 
-	@JsonAnySetter
-	public void setAdditionalProperty(String name, Object value) {
-		this.additionalProperties.put(name, value);
-	}
+  @JsonAnySetter
+  public void setAdditionalProperty(String name, Object value) {
+    this.additionalProperties.put(name, value);
+  }
 
 }

--- a/src/main/java/com/oneops/api/resource/model/RfcCi.java
+++ b/src/main/java/com/oneops/api/resource/model/RfcCi.java
@@ -11,335 +11,335 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
-@JsonPropertyOrder({ "rfcId", "releaseId", "ciId", "nsPath", "ciClassName", "impl", "ciName", "ciGoid", "ciState",
-		"rfcAction", "releaseType", "createdBy", "updatedBy", "rfcCreatedBy", "rfcUpdatedBy", "execOrder",
-		"lastAppliedRfcId", "comments", "isActiveInRelease", "rfcCreated", "rfcUpdated", "created", "updated",
-		"ciAttributes", "ciAttrProps", "deployment" })
+@JsonPropertyOrder({"rfcId", "releaseId", "ciId", "nsPath", "ciClassName", "impl", "ciName", "ciGoid", "ciState",
+    "rfcAction", "releaseType", "createdBy", "updatedBy", "rfcCreatedBy", "rfcUpdatedBy", "execOrder",
+    "lastAppliedRfcId", "comments", "isActiveInRelease", "rfcCreated", "rfcUpdated", "created", "updated",
+    "ciAttributes", "ciAttrProps", "deployment"})
 public class RfcCi {
 
-	@JsonProperty("rfcId")
-	private Long rfcId;
-	@JsonProperty("releaseId")
-	private Long releaseId;
-	@JsonProperty("ciId")
-	private Long ciId;
-	@JsonProperty("nsPath")
-	private String nsPath;
-	@JsonProperty("ciClassName")
-	private String ciClassName;
-	@JsonProperty("impl")
-	private String impl;
-	@JsonProperty("ciName")
-	private String ciName;
-	@JsonProperty("ciGoid")
-	private String ciGoid;
-	@JsonProperty("ciState")
-	private Object ciState;
-	@JsonProperty("rfcAction")
-	private String rfcAction;
-	@JsonProperty("releaseType")
-	private Object releaseType;
-	@JsonProperty("createdBy")
-	private String createdBy;
-	@JsonProperty("updatedBy")
-	private Object updatedBy;
-	@JsonProperty("rfcCreatedBy")
-	private String rfcCreatedBy;
-	@JsonProperty("rfcUpdatedBy")
-	private Object rfcUpdatedBy;
-	@JsonProperty("execOrder")
-	private Long execOrder;
-	@JsonProperty("lastAppliedRfcId")
-	private Object lastAppliedRfcId;
-	@JsonProperty("comments")
-	private Object comments;
-	@JsonProperty("isActiveInRelease")
-	private Boolean isActiveInRelease;
-	@JsonProperty("rfcCreated")
-	private Long rfcCreated;
-	@JsonProperty("rfcUpdated")
-	private Long rfcUpdated;
-	@JsonProperty("created")
-	private Long created;
-	@JsonProperty("updated")
-	private Long updated;
-	@JsonProperty("ciAttributes")
-	private CiAttributes ciAttributes;
-	@JsonProperty("ciAttrProps")
-	private AttrProps ciAttrProps;
-	@JsonProperty("deployment")
-	private Deployment deployment;
-	@JsonIgnore
-	private Map<String, Object> additionalProperties = new HashMap<String, Object>();
+  @JsonProperty("rfcId")
+  private Long rfcId;
+  @JsonProperty("releaseId")
+  private Long releaseId;
+  @JsonProperty("ciId")
+  private Long ciId;
+  @JsonProperty("nsPath")
+  private String nsPath;
+  @JsonProperty("ciClassName")
+  private String ciClassName;
+  @JsonProperty("impl")
+  private String impl;
+  @JsonProperty("ciName")
+  private String ciName;
+  @JsonProperty("ciGoid")
+  private String ciGoid;
+  @JsonProperty("ciState")
+  private Object ciState;
+  @JsonProperty("rfcAction")
+  private String rfcAction;
+  @JsonProperty("releaseType")
+  private Object releaseType;
+  @JsonProperty("createdBy")
+  private String createdBy;
+  @JsonProperty("updatedBy")
+  private Object updatedBy;
+  @JsonProperty("rfcCreatedBy")
+  private String rfcCreatedBy;
+  @JsonProperty("rfcUpdatedBy")
+  private Object rfcUpdatedBy;
+  @JsonProperty("execOrder")
+  private Long execOrder;
+  @JsonProperty("lastAppliedRfcId")
+  private Object lastAppliedRfcId;
+  @JsonProperty("comments")
+  private Object comments;
+  @JsonProperty("isActiveInRelease")
+  private Boolean isActiveInRelease;
+  @JsonProperty("rfcCreated")
+  private Long rfcCreated;
+  @JsonProperty("rfcUpdated")
+  private Long rfcUpdated;
+  @JsonProperty("created")
+  private Long created;
+  @JsonProperty("updated")
+  private Long updated;
+  @JsonProperty("ciAttributes")
+  private CiAttributes ciAttributes;
+  @JsonProperty("ciAttrProps")
+  private AttrProps ciAttrProps;
+  @JsonProperty("deployment")
+  private Deployment deployment;
+  @JsonIgnore
+  private Map<String, Object> additionalProperties = new HashMap<String, Object>();
 
-	@JsonProperty("rfcId")
-	public Long getRfcId() {
-		return rfcId;
-	}
+  @JsonProperty("rfcId")
+  public Long getRfcId() {
+    return rfcId;
+  }
 
-	@JsonProperty("rfcId")
-	public void setRfcId(Long rfcId) {
-		this.rfcId = rfcId;
-	}
+  @JsonProperty("rfcId")
+  public void setRfcId(Long rfcId) {
+    this.rfcId = rfcId;
+  }
 
-	@JsonProperty("releaseId")
-	public Long getReleaseId() {
-		return releaseId;
-	}
+  @JsonProperty("releaseId")
+  public Long getReleaseId() {
+    return releaseId;
+  }
 
-	@JsonProperty("releaseId")
-	public void setReleaseId(Long releaseId) {
-		this.releaseId = releaseId;
-	}
+  @JsonProperty("releaseId")
+  public void setReleaseId(Long releaseId) {
+    this.releaseId = releaseId;
+  }
 
-	@JsonProperty("ciId")
-	public Long getCiId() {
-		return ciId;
-	}
+  @JsonProperty("ciId")
+  public Long getCiId() {
+    return ciId;
+  }
 
-	@JsonProperty("ciId")
-	public void setCiId(Long ciId) {
-		this.ciId = ciId;
-	}
+  @JsonProperty("ciId")
+  public void setCiId(Long ciId) {
+    this.ciId = ciId;
+  }
 
-	@JsonProperty("nsPath")
-	public String getNsPath() {
-		return nsPath;
-	}
+  @JsonProperty("nsPath")
+  public String getNsPath() {
+    return nsPath;
+  }
 
-	@JsonProperty("nsPath")
-	public void setNsPath(String nsPath) {
-		this.nsPath = nsPath;
-	}
+  @JsonProperty("nsPath")
+  public void setNsPath(String nsPath) {
+    this.nsPath = nsPath;
+  }
 
-	@JsonProperty("ciClassName")
-	public String getCiClassName() {
-		return ciClassName;
-	}
+  @JsonProperty("ciClassName")
+  public String getCiClassName() {
+    return ciClassName;
+  }
 
-	@JsonProperty("ciClassName")
-	public void setCiClassName(String ciClassName) {
-		this.ciClassName = ciClassName;
-	}
+  @JsonProperty("ciClassName")
+  public void setCiClassName(String ciClassName) {
+    this.ciClassName = ciClassName;
+  }
 
-	@JsonProperty("impl")
-	public String getImpl() {
-		return impl;
-	}
+  @JsonProperty("impl")
+  public String getImpl() {
+    return impl;
+  }
 
-	@JsonProperty("impl")
-	public void setImpl(String impl) {
-		this.impl = impl;
-	}
+  @JsonProperty("impl")
+  public void setImpl(String impl) {
+    this.impl = impl;
+  }
 
-	@JsonProperty("ciName")
-	public String getCiName() {
-		return ciName;
-	}
+  @JsonProperty("ciName")
+  public String getCiName() {
+    return ciName;
+  }
 
-	@JsonProperty("ciName")
-	public void setCiName(String ciName) {
-		this.ciName = ciName;
-	}
+  @JsonProperty("ciName")
+  public void setCiName(String ciName) {
+    this.ciName = ciName;
+  }
 
-	@JsonProperty("ciGoid")
-	public String getCiGoid() {
-		return ciGoid;
-	}
+  @JsonProperty("ciGoid")
+  public String getCiGoid() {
+    return ciGoid;
+  }
 
-	@JsonProperty("ciGoid")
-	public void setCiGoid(String ciGoid) {
-		this.ciGoid = ciGoid;
-	}
+  @JsonProperty("ciGoid")
+  public void setCiGoid(String ciGoid) {
+    this.ciGoid = ciGoid;
+  }
 
-	@JsonProperty("ciState")
-	public Object getCiState() {
-		return ciState;
-	}
+  @JsonProperty("ciState")
+  public Object getCiState() {
+    return ciState;
+  }
 
-	@JsonProperty("ciState")
-	public void setCiState(Object ciState) {
-		this.ciState = ciState;
-	}
+  @JsonProperty("ciState")
+  public void setCiState(Object ciState) {
+    this.ciState = ciState;
+  }
 
-	@JsonProperty("rfcAction")
-	public String getRfcAction() {
-		return rfcAction;
-	}
+  @JsonProperty("rfcAction")
+  public String getRfcAction() {
+    return rfcAction;
+  }
 
-	@JsonProperty("rfcAction")
-	public void setRfcAction(String rfcAction) {
-		this.rfcAction = rfcAction;
-	}
+  @JsonProperty("rfcAction")
+  public void setRfcAction(String rfcAction) {
+    this.rfcAction = rfcAction;
+  }
 
-	@JsonProperty("releaseType")
-	public Object getReleaseType() {
-		return releaseType;
-	}
+  @JsonProperty("releaseType")
+  public Object getReleaseType() {
+    return releaseType;
+  }
 
-	@JsonProperty("releaseType")
-	public void setReleaseType(Object releaseType) {
-		this.releaseType = releaseType;
-	}
+  @JsonProperty("releaseType")
+  public void setReleaseType(Object releaseType) {
+    this.releaseType = releaseType;
+  }
 
-	@JsonProperty("createdBy")
-	public String getCreatedBy() {
-		return createdBy;
-	}
+  @JsonProperty("createdBy")
+  public String getCreatedBy() {
+    return createdBy;
+  }
 
-	@JsonProperty("createdBy")
-	public void setCreatedBy(String createdBy) {
-		this.createdBy = createdBy;
-	}
+  @JsonProperty("createdBy")
+  public void setCreatedBy(String createdBy) {
+    this.createdBy = createdBy;
+  }
 
-	@JsonProperty("updatedBy")
-	public Object getUpdatedBy() {
-		return updatedBy;
-	}
+  @JsonProperty("updatedBy")
+  public Object getUpdatedBy() {
+    return updatedBy;
+  }
 
-	@JsonProperty("updatedBy")
-	public void setUpdatedBy(Object updatedBy) {
-		this.updatedBy = updatedBy;
-	}
+  @JsonProperty("updatedBy")
+  public void setUpdatedBy(Object updatedBy) {
+    this.updatedBy = updatedBy;
+  }
 
-	@JsonProperty("rfcCreatedBy")
-	public String getRfcCreatedBy() {
-		return rfcCreatedBy;
-	}
+  @JsonProperty("rfcCreatedBy")
+  public String getRfcCreatedBy() {
+    return rfcCreatedBy;
+  }
 
-	@JsonProperty("rfcCreatedBy")
-	public void setRfcCreatedBy(String rfcCreatedBy) {
-		this.rfcCreatedBy = rfcCreatedBy;
-	}
+  @JsonProperty("rfcCreatedBy")
+  public void setRfcCreatedBy(String rfcCreatedBy) {
+    this.rfcCreatedBy = rfcCreatedBy;
+  }
 
-	@JsonProperty("rfcUpdatedBy")
-	public Object getRfcUpdatedBy() {
-		return rfcUpdatedBy;
-	}
+  @JsonProperty("rfcUpdatedBy")
+  public Object getRfcUpdatedBy() {
+    return rfcUpdatedBy;
+  }
 
-	@JsonProperty("rfcUpdatedBy")
-	public void setRfcUpdatedBy(Object rfcUpdatedBy) {
-		this.rfcUpdatedBy = rfcUpdatedBy;
-	}
+  @JsonProperty("rfcUpdatedBy")
+  public void setRfcUpdatedBy(Object rfcUpdatedBy) {
+    this.rfcUpdatedBy = rfcUpdatedBy;
+  }
 
-	@JsonProperty("execOrder")
-	public Long getExecOrder() {
-		return execOrder;
-	}
+  @JsonProperty("execOrder")
+  public Long getExecOrder() {
+    return execOrder;
+  }
 
-	@JsonProperty("execOrder")
-	public void setExecOrder(Long execOrder) {
-		this.execOrder = execOrder;
-	}
+  @JsonProperty("execOrder")
+  public void setExecOrder(Long execOrder) {
+    this.execOrder = execOrder;
+  }
 
-	@JsonProperty("lastAppliedRfcId")
-	public Object getLastAppliedRfcId() {
-		return lastAppliedRfcId;
-	}
+  @JsonProperty("lastAppliedRfcId")
+  public Object getLastAppliedRfcId() {
+    return lastAppliedRfcId;
+  }
 
-	@JsonProperty("lastAppliedRfcId")
-	public void setLastAppliedRfcId(Object lastAppliedRfcId) {
-		this.lastAppliedRfcId = lastAppliedRfcId;
-	}
+  @JsonProperty("lastAppliedRfcId")
+  public void setLastAppliedRfcId(Object lastAppliedRfcId) {
+    this.lastAppliedRfcId = lastAppliedRfcId;
+  }
 
-	@JsonProperty("comments")
-	public Object getComments() {
-		return comments;
-	}
+  @JsonProperty("comments")
+  public Object getComments() {
+    return comments;
+  }
 
-	@JsonProperty("comments")
-	public void setComments(Object comments) {
-		this.comments = comments;
-	}
+  @JsonProperty("comments")
+  public void setComments(Object comments) {
+    this.comments = comments;
+  }
 
-	@JsonProperty("isActiveInRelease")
-	public Boolean getIsActiveInRelease() {
-		return isActiveInRelease;
-	}
+  @JsonProperty("isActiveInRelease")
+  public Boolean getIsActiveInRelease() {
+    return isActiveInRelease;
+  }
 
-	@JsonProperty("isActiveInRelease")
-	public void setIsActiveInRelease(Boolean isActiveInRelease) {
-		this.isActiveInRelease = isActiveInRelease;
-	}
+  @JsonProperty("isActiveInRelease")
+  public void setIsActiveInRelease(Boolean isActiveInRelease) {
+    this.isActiveInRelease = isActiveInRelease;
+  }
 
-	@JsonProperty("rfcCreated")
-	public Long getRfcCreated() {
-		return rfcCreated;
-	}
+  @JsonProperty("rfcCreated")
+  public Long getRfcCreated() {
+    return rfcCreated;
+  }
 
-	@JsonProperty("rfcCreated")
-	public void setRfcCreated(Long rfcCreated) {
-		this.rfcCreated = rfcCreated;
-	}
+  @JsonProperty("rfcCreated")
+  public void setRfcCreated(Long rfcCreated) {
+    this.rfcCreated = rfcCreated;
+  }
 
-	@JsonProperty("rfcUpdated")
-	public Long getRfcUpdated() {
-		return rfcUpdated;
-	}
+  @JsonProperty("rfcUpdated")
+  public Long getRfcUpdated() {
+    return rfcUpdated;
+  }
 
-	@JsonProperty("rfcUpdated")
-	public void setRfcUpdated(Long rfcUpdated) {
-		this.rfcUpdated = rfcUpdated;
-	}
+  @JsonProperty("rfcUpdated")
+  public void setRfcUpdated(Long rfcUpdated) {
+    this.rfcUpdated = rfcUpdated;
+  }
 
-	@JsonProperty("created")
-	public Long getCreated() {
-		return created;
-	}
+  @JsonProperty("created")
+  public Long getCreated() {
+    return created;
+  }
 
-	@JsonProperty("created")
-	public void setCreated(Long created) {
-		this.created = created;
-	}
+  @JsonProperty("created")
+  public void setCreated(Long created) {
+    this.created = created;
+  }
 
-	@JsonProperty("updated")
-	public Long getUpdated() {
-		return updated;
-	}
+  @JsonProperty("updated")
+  public Long getUpdated() {
+    return updated;
+  }
 
-	@JsonProperty("updated")
-	public void setUpdated(Long updated) {
-		this.updated = updated;
-	}
+  @JsonProperty("updated")
+  public void setUpdated(Long updated) {
+    this.updated = updated;
+  }
 
-	@JsonProperty("ciAttributes")
-	public CiAttributes getCiAttributes() {
-		return ciAttributes;
-	}
+  @JsonProperty("ciAttributes")
+  public CiAttributes getCiAttributes() {
+    return ciAttributes;
+  }
 
-	@JsonProperty("ciAttributes")
-	public void setCiAttributes(CiAttributes ciAttributes) {
-		this.ciAttributes = ciAttributes;
-	}
+  @JsonProperty("ciAttributes")
+  public void setCiAttributes(CiAttributes ciAttributes) {
+    this.ciAttributes = ciAttributes;
+  }
 
-	@JsonProperty("ciAttrProps")
-	public AttrProps getCiAttrProps() {
-		return ciAttrProps;
-	}
+  @JsonProperty("ciAttrProps")
+  public AttrProps getCiAttrProps() {
+    return ciAttrProps;
+  }
 
-	@JsonProperty("ciAttrProps")
-	public void setCiAttrProps(AttrProps ciAttrProps) {
-		this.ciAttrProps = ciAttrProps;
-	}
+  @JsonProperty("ciAttrProps")
+  public void setCiAttrProps(AttrProps ciAttrProps) {
+    this.ciAttrProps = ciAttrProps;
+  }
 
-	@JsonProperty("deployment")
-	public Deployment getDeployment() {
-		return deployment;
-	}
+  @JsonProperty("deployment")
+  public Deployment getDeployment() {
+    return deployment;
+  }
 
-	@JsonProperty("deployment")
-	public void setDeployment(Deployment deployment) {
-		this.deployment = deployment;
-	}
+  @JsonProperty("deployment")
+  public void setDeployment(Deployment deployment) {
+    this.deployment = deployment;
+  }
 
-	@JsonAnyGetter
-	public Map<String, Object> getAdditionalProperties() {
-		return this.additionalProperties;
-	}
+  @JsonAnyGetter
+  public Map<String, Object> getAdditionalProperties() {
+    return this.additionalProperties;
+  }
 
-	@JsonAnySetter
-	public void setAdditionalProperty(String name, Object value) {
-		this.additionalProperties.put(name, value);
-	}
+  @JsonAnySetter
+  public void setAdditionalProperty(String name, Object value) {
+    this.additionalProperties.put(name, value);
+  }
 
 }

--- a/src/main/java/com/oneops/api/util/IConstants.java
+++ b/src/main/java/com/oneops/api/util/IConstants.java
@@ -1,22 +1,22 @@
 package com.oneops.api.util;
 
 public interface IConstants {
-	static String ASSEMBLY_URI = "/assemblies/";
-	static String DESIGN_URI = "/design";
-	static String RELEASES_URI = "/releases/";
-	static String ENVIRONMENT_URI = "/environments/";
-	static String TRANSITION_URI = "/transition";
-	static String OPERATION_URI = "/operations";
-	static String PLATFORM_URI = "/platforms/";
-	static String COMPONENT_URI = "/components/";
-	static String CLOUDS_URI = "/clouds/";
-	static String ACCOUNT_URI = "/account/organizations/";
-	static String ORGANIZATION_URI = "/organization/";
-	static String VARIABLES_URI = "/variables/";
-	static String ATTACHMENTS_URI = "/attachments/";
-	static String ACTIONS_URI = "/actions/";
-	static String PROCEDURES_URI = "/procedures/";
-	static String INSTANCES_URI = "/instances/";
-	static String MONITORS_URI = "/monitors/";
-	static String DEPLOYMENTS_URI = "/deployments/";
+  static String ASSEMBLY_URI = "/assemblies/";
+  static String DESIGN_URI = "/design";
+  static String RELEASES_URI = "/releases/";
+  static String ENVIRONMENT_URI = "/environments/";
+  static String TRANSITION_URI = "/transition";
+  static String OPERATION_URI = "/operations";
+  static String PLATFORM_URI = "/platforms/";
+  static String COMPONENT_URI = "/components/";
+  static String CLOUDS_URI = "/clouds/";
+  static String ACCOUNT_URI = "/account/organizations/";
+  static String ORGANIZATION_URI = "/organization/";
+  static String VARIABLES_URI = "/variables/";
+  static String ATTACHMENTS_URI = "/attachments/";
+  static String ACTIONS_URI = "/actions/";
+  static String PROCEDURES_URI = "/procedures/";
+  static String INSTANCES_URI = "/instances/";
+  static String MONITORS_URI = "/monitors/";
+  static String DEPLOYMENTS_URI = "/deployments/";
 }

--- a/src/main/java/com/oneops/api/util/JsonUtil.java
+++ b/src/main/java/com/oneops/api/util/JsonUtil.java
@@ -10,54 +10,54 @@ import com.oneops.api.ResourceObject;
 
 public class JsonUtil {
 
-	public static <T> T toObject(String jsonStr, TypeReference<T> t) {
-		ObjectMapper mapper = new ObjectMapper();
-		T object = null;
-		try {
-			object = mapper.readValue(jsonStr, t);
-		} catch (Exception e) {
-		}
-		return object;
-	}
-	
-	public static JSONObject createJsonObject(ResourceObject ro, String root) {
-		JSONObject rootObject = new JSONObject();
-		JSONObject jsonObject = new JSONObject();
-		if(ro != null) {
-			if(ro.getProperties() != null && ro.getProperties().size() > 0) {
-				for (Entry<String, String> entry : ro.getProperties().entrySet()) {
-					jsonObject.put(entry.getKey(), entry.getValue());
-				}
-			}
-			if(ro.getAttributes() != null && ro.getAttributes().size() > 0) {
-				JSONObject attr = new JSONObject();
-				for (Entry<String, String> entry : ro.getAttributes().entrySet()) {
-					attr.put(entry.getKey(), entry.getValue());
-				}
-				jsonObject.put("ciAttributes", attr);
-			}
-			if(ro.getOwnerProps() != null && ro.getOwnerProps().size() > 0) {
-				JSONObject attr = new JSONObject();
-				for (Entry<String, String> entry : ro.getOwnerProps().entrySet()) {
-					attr.put(entry.getKey(), entry.getValue());
-				}
-				JSONObject owner = new JSONObject();
-				owner.put("owner", attr);
-				jsonObject.put("ciAttrProps", owner);
-			}
-		}
-		if(root != null) {
-			rootObject.put(root, jsonObject);
-		} else {
-			rootObject = jsonObject;
-		}
-		return rootObject;
-	}
-	
-	public static JSONObject createJsonObject(String str) {
-		JSONObject jsonObject = new JSONObject(str);
-		return jsonObject;
-	}
-	
-	
+  public static <T> T toObject(String jsonStr, TypeReference<T> t) {
+    ObjectMapper mapper = new ObjectMapper();
+    T object = null;
+    try {
+      object = mapper.readValue(jsonStr, t);
+    } catch (Exception e) {
+    }
+    return object;
+  }
+
+  public static JSONObject createJsonObject(ResourceObject ro, String root) {
+    JSONObject rootObject = new JSONObject();
+    JSONObject jsonObject = new JSONObject();
+    if (ro != null) {
+      if (ro.getProperties() != null && ro.getProperties().size() > 0) {
+        for (Entry<String, String> entry : ro.getProperties().entrySet()) {
+          jsonObject.put(entry.getKey(), entry.getValue());
+        }
+      }
+      if (ro.getAttributes() != null && ro.getAttributes().size() > 0) {
+        JSONObject attr = new JSONObject();
+        for (Entry<String, String> entry : ro.getAttributes().entrySet()) {
+          attr.put(entry.getKey(), entry.getValue());
+        }
+        jsonObject.put("ciAttributes", attr);
+      }
+      if (ro.getOwnerProps() != null && ro.getOwnerProps().size() > 0) {
+        JSONObject attr = new JSONObject();
+        for (Entry<String, String> entry : ro.getOwnerProps().entrySet()) {
+          attr.put(entry.getKey(), entry.getValue());
+        }
+        JSONObject owner = new JSONObject();
+        owner.put("owner", attr);
+        jsonObject.put("ciAttrProps", owner);
+      }
+    }
+    if (root != null) {
+      rootObject.put(root, jsonObject);
+    } else {
+      rootObject = jsonObject;
+    }
+    return rootObject;
+  }
+
+  public static JSONObject createJsonObject(String str) {
+    JSONObject jsonObject = new JSONObject(str);
+    return jsonObject;
+  }
+
+
 }


### PR DESCRIPTION
I realize this looks frightening but I wanted to get all the API calls into the APIClient class to start removing the boilerplate. The class will likely be 1/20th of its size using Gson/Moshi and we might need a few custom de/serializers but not many.

But before going any further I'd like to integrate Boo's configuration method for testing so that it's easy to setup testing against a live OneOps instance for integration testing. Once there are more tests I'll be more comfortable refactoring.

I also applied the Google code style.