### PR TITLE
Improve error message when component deletion fails

### DIFF
--- a/src/main/java/com/oneops/api/resource/Design.java
+++ b/src/main/java/com/oneops/api/resource/Design.java
@@ -640,11 +640,15 @@ public class Design extends APIClient {
 			if(response.getStatusCode() == 200 || response.getStatusCode() == 302) {
 				return response.getBody().as(CiResource.class);
 			} else {
-				String msg = String.format("Failed to delete platform with name %s due to %s", platformName, response.getStatusLine());
+				String msg = String.format("Failed to delete component '%s' of platform '%s' due to %s: %s",
+																	 componentName,
+																	 platformName,
+																	 response.getStatusLine(),
+																	 response.getBody().asString());
 				throw new OneOpsClientAPIException(msg);
 			}
-		} 
-		String msg = String.format("Failed to delete platform with name %s due to null response", platformName);
+		}
+		String msg = String.format("Failed to delete component '%s' of platform '%s' due to null response", componentName, platformName);
 		throw new OneOpsClientAPIException(msg);
 	}
 	

--- a/src/main/java/com/oneops/api/resource/Design.java
+++ b/src/main/java/com/oneops/api/resource/Design.java
@@ -640,11 +640,7 @@ public class Design extends APIClient {
 			if(response.getStatusCode() == 200 || response.getStatusCode() == 302) {
 				return response.getBody().as(CiResource.class);
 			} else {
-				String msg = String.format("Failed to delete component '%s' of platform '%s' due to %s: %s",
-																	 componentName,
-																	 platformName,
-																	 response.getStatusLine(),
-																	 response.getBody().asString());
+				String msg = String.format("Failed to delete component '%s' of platform '%s' due to %s: %s", componentName, platformName, response.getStatusLine(), response.getBody().asString());
 				throw new OneOpsClientAPIException(msg);
 			}
 		}


### PR DESCRIPTION
Previously, the OneOps API client yielded a stack trace with the following message:

`com.oneops.api.exception.OneOpsClientAPIException: Failed to delete platform with name riemann due to HTTP/1.1 422 Unprocessable Entity`

This message leaves out the specific *component* at issue in the platform. Further, it doesn't include the response body, which can contain useful debugging information.

With this PR applied, the API client yields the following exception message:

`com.oneops.api.exception.OneOpsClientAPIException: Failed to delete component 'fqdn' of platform 'riemann' due to HTTP/1.1 422 Unprocessable Entity: {"errors":["Cannot delete required component."]}`

...which makes it much more clear which component is faulty, and the root cause of the fault.

---

Note that the API client almost always seems to discard the response body for an error response. If this PR is merged, I may submit another one to address that issue more widely.